### PR TITLE
FEAT(db): initialize Flyway migration schema V1-V17

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/biot_db
+    username: postgres
+    password: postgres
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/resources/db/migration/V10__alter_room.sql
+++ b/src/main/resources/db/migration/V10__alter_room.sql
@@ -1,0 +1,9 @@
+-- Drop all tables that hold FK references to room.room_id
+DROP TABLE alert_log;
+DROP TABLE control_log;
+DROP TABLE sensor_data;
+DROP TABLE room_device;
+DROP TABLE sensor;
+
+-- Remove the legacy business-key column; id (BIGSERIAL) becomes the sole PK
+ALTER TABLE room DROP COLUMN room_id;

--- a/src/main/resources/db/migration/V11__alter_device.sql
+++ b/src/main/resources/db/migration/V11__alter_device.sql
@@ -1,0 +1,10 @@
+ALTER TABLE device DROP COLUMN device_id;
+ALTER TABLE device DROP COLUMN type;
+
+ALTER TABLE device ALTER COLUMN name SET NOT NULL;
+ALTER TABLE device ADD CONSTRAINT device_name_unique UNIQUE (name);
+
+ALTER TABLE device ADD COLUMN power_watt INTEGER;
+UPDATE device SET power_watt = 50   WHERE name = '조명';
+UPDATE device SET power_watt = 1500 WHERE name = '에어컨';
+ALTER TABLE device ALTER COLUMN power_watt SET NOT NULL;

--- a/src/main/resources/db/migration/V12__recreate_sensor.sql
+++ b/src/main/resources/db/migration/V12__recreate_sensor.sql
@@ -1,0 +1,30 @@
+CREATE TABLE sensor (
+    id             BIGSERIAL    PRIMARY KEY,
+    identifier     VARCHAR(50)  NOT NULL UNIQUE,
+    sensor_type_id BIGINT       NOT NULL,
+    room_id        BIGINT       NOT NULL,
+    name           VARCHAR(100),
+    created_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (sensor_type_id) REFERENCES sensor_type(id),
+    FOREIGN KEY (room_id)        REFERENCES room(id)
+);
+
+INSERT INTO sensor (identifier, sensor_type_id, room_id, name)
+SELECT 'pir-101', st.id, r.id, '1층 회의실 PIR 센서'
+FROM sensor_type st, room r WHERE st.name = 'PIR' AND r.name = '1층 회의실'
+UNION ALL
+SELECT 'dht-101', st.id, r.id, '1층 회의실 온습도 센서'
+FROM sensor_type st, room r WHERE st.name = 'DHT22' AND r.name = '1층 회의실'
+UNION ALL
+SELECT 'pir-102', st.id, r.id, '1층 사무실 PIR 센서'
+FROM sensor_type st, room r WHERE st.name = 'PIR' AND r.name = '1층 사무실'
+UNION ALL
+SELECT 'dht-102', st.id, r.id, '1층 사무실 온습도 센서'
+FROM sensor_type st, room r WHERE st.name = 'DHT22' AND r.name = '1층 사무실'
+UNION ALL
+SELECT 'pir-103', st.id, r.id, '2층 회의실 PIR 센서'
+FROM sensor_type st, room r WHERE st.name = 'PIR' AND r.name = '2층 회의실'
+UNION ALL
+SELECT 'dht-103', st.id, r.id, '2층 회의실 온습도 센서'
+FROM sensor_type st, room r WHERE st.name = 'DHT22' AND r.name = '2층 회의실';

--- a/src/main/resources/db/migration/V13__recreate_room_device.sql
+++ b/src/main/resources/db/migration/V13__recreate_room_device.sql
@@ -1,0 +1,16 @@
+CREATE TABLE room_device (
+    room_id    BIGINT      NOT NULL,
+    device_id  BIGINT      NOT NULL,
+    status     VARCHAR(10) NOT NULL DEFAULT 'OFF',
+    mode       VARCHAR(10) NOT NULL DEFAULT 'AUTO',
+    updated_at TIMESTAMP   NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (room_id, device_id),
+    FOREIGN KEY (room_id)  REFERENCES room(id),
+    FOREIGN KEY (device_id) REFERENCES device(id)
+);
+
+INSERT INTO room_device (room_id, device_id, status, mode)
+SELECT r.id, d.id, 'OFF', 'AUTO'
+FROM room r
+CROSS JOIN device d;

--- a/src/main/resources/db/migration/V14__recreate_sensor_data.sql
+++ b/src/main/resources/db/migration/V14__recreate_sensor_data.sql
@@ -1,0 +1,11 @@
+CREATE TABLE sensor_data (
+    id          BIGSERIAL    PRIMARY KEY,
+    sensor_id   BIGINT       NOT NULL,
+    temperature DECIMAL(5,2),
+    humidity    DECIMAL(5,2),
+    motion      SMALLINT,
+    status      VARCHAR(20)  NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (sensor_id) REFERENCES sensor(id)
+);

--- a/src/main/resources/db/migration/V15__recreate_control_log.sql
+++ b/src/main/resources/db/migration/V15__recreate_control_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE control_log (
+    id         BIGSERIAL   PRIMARY KEY,
+    room_id    BIGINT      NOT NULL,
+    device_id  BIGINT      NOT NULL,
+    action     VARCHAR(10) NOT NULL,
+    type       VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP   NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id)  REFERENCES room(id),
+    FOREIGN KEY (device_id) REFERENCES device(id)
+);

--- a/src/main/resources/db/migration/V16__recreate_alert_log.sql
+++ b/src/main/resources/db/migration/V16__recreate_alert_log.sql
@@ -1,0 +1,9 @@
+CREATE TABLE alert_log (
+    id         BIGSERIAL    PRIMARY KEY,
+    sensor_id  BIGINT       NOT NULL,
+    type       VARCHAR(30)  NOT NULL,
+    message    VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (sensor_id) REFERENCES sensor(id)
+);

--- a/src/main/resources/db/migration/V17__add_indexes.sql
+++ b/src/main/resources/db/migration/V17__add_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_sensor_data_sensor_created ON sensor_data (sensor_id, created_at);
+
+CREATE INDEX idx_control_log_room_created ON control_log (room_id, created_at);
+
+CREATE INDEX idx_alert_log_sensor_created ON alert_log (sensor_id, created_at);

--- a/src/main/resources/db/migration/V1__create_room.sql
+++ b/src/main/resources/db/migration/V1__create_room.sql
@@ -1,0 +1,12 @@
+CREATE TABLE room (
+    id         BIGSERIAL    PRIMARY KEY,
+    room_id    VARCHAR(50)  NOT NULL UNIQUE,
+    name       VARCHAR(100) NOT NULL,
+    floor      INTEGER,
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO room (room_id, name, floor) VALUES
+    ('room-101', '1층 회의실', 1),
+    ('room-102', '1층 사무실', 1),
+    ('room-103', '2층 회의실', 2);

--- a/src/main/resources/db/migration/V2__create_sensor.sql
+++ b/src/main/resources/db/migration/V2__create_sensor.sql
@@ -1,0 +1,18 @@
+CREATE TABLE sensor (
+    id         BIGSERIAL    PRIMARY KEY,
+    sensor_id  VARCHAR(50)  NOT NULL UNIQUE,
+    room_id    VARCHAR(50)  NOT NULL,
+    type       VARCHAR(20)  NOT NULL,
+    name       VARCHAR(100),
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id) REFERENCES room(room_id)
+);
+
+INSERT INTO sensor (sensor_id, room_id, type, name) VALUES
+    ('pir-101', 'room-101', 'PIR',   '1층 회의실 PIR 센서'),
+    ('dht-101', 'room-101', 'DHT22', '1층 회의실 온습도 센서'),
+    ('pir-102', 'room-102', 'PIR',   '1층 사무실 PIR 센서'),
+    ('dht-102', 'room-102', 'DHT22', '1층 사무실 온습도 센서'),
+    ('pir-103', 'room-103', 'PIR',   '2층 회의실 PIR 센서'),
+    ('dht-103', 'room-103', 'DHT22', '2층 회의실 온습도 센서');

--- a/src/main/resources/db/migration/V3__create_room_device.sql
+++ b/src/main/resources/db/migration/V3__create_room_device.sql
@@ -1,0 +1,19 @@
+CREATE TABLE room_device (
+    id         BIGSERIAL   PRIMARY KEY,
+    room_id    VARCHAR(50) NOT NULL,
+    device     VARCHAR(20) NOT NULL,
+    status     VARCHAR(10) NOT NULL DEFAULT 'OFF',
+    mode       VARCHAR(10) NOT NULL DEFAULT 'AUTO',
+    updated_at TIMESTAMP   NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id) REFERENCES room(room_id),
+    UNIQUE (room_id, device)
+);
+
+INSERT INTO room_device (room_id, device, status, mode) VALUES
+    ('room-101', 'LIGHT', 'OFF', 'AUTO'),
+    ('room-101', 'AC',    'OFF', 'AUTO'),
+    ('room-102', 'LIGHT', 'OFF', 'AUTO'),
+    ('room-102', 'AC',    'OFF', 'AUTO'),
+    ('room-103', 'LIGHT', 'OFF', 'AUTO'),
+    ('room-103', 'AC',    'OFF', 'AUTO');

--- a/src/main/resources/db/migration/V4__create_sensor_data.sql
+++ b/src/main/resources/db/migration/V4__create_sensor_data.sql
@@ -1,0 +1,13 @@
+CREATE TABLE sensor_data (
+    id          BIGSERIAL    PRIMARY KEY,
+    sensor_id   VARCHAR(50)  NOT NULL,
+    room_id     VARCHAR(50)  NOT NULL,
+    temperature DECIMAL(5,2),
+    humidity    DECIMAL(5,2),
+    motion      SMALLINT,
+    status      VARCHAR(20)  NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (sensor_id) REFERENCES sensor(sensor_id),
+    FOREIGN KEY (room_id)   REFERENCES room(room_id)
+);

--- a/src/main/resources/db/migration/V5__create_control_log.sql
+++ b/src/main/resources/db/migration/V5__create_control_log.sql
@@ -1,0 +1,10 @@
+CREATE TABLE control_log (
+    id         BIGSERIAL   PRIMARY KEY,
+    room_id    VARCHAR(50) NOT NULL,
+    device     VARCHAR(20) NOT NULL,
+    action     VARCHAR(10) NOT NULL,
+    type       VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP   NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id) REFERENCES room(room_id)
+);

--- a/src/main/resources/db/migration/V6__create_alert_log.sql
+++ b/src/main/resources/db/migration/V6__create_alert_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE alert_log (
+    id         BIGSERIAL    PRIMARY KEY,
+    room_id    VARCHAR(50)  NOT NULL,
+    sensor_id  VARCHAR(50)  NOT NULL,
+    type       VARCHAR(30)  NOT NULL,
+    message    VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id)   REFERENCES room(room_id),
+    FOREIGN KEY (sensor_id) REFERENCES sensor(sensor_id)
+);

--- a/src/main/resources/db/migration/V7__create_device.sql
+++ b/src/main/resources/db/migration/V7__create_device.sql
@@ -1,0 +1,11 @@
+CREATE TABLE device (
+    id         BIGSERIAL    PRIMARY KEY,
+    device_id  VARCHAR(50)  NOT NULL UNIQUE,
+    type       VARCHAR(20)  NOT NULL,
+    name       VARCHAR(100),
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO device (device_id, type, name) VALUES
+    ('device-light', 'LIGHT', '조명'),
+    ('device-ac',    'AC',    '에어컨');

--- a/src/main/resources/db/migration/V8__alter_room_device.sql
+++ b/src/main/resources/db/migration/V8__alter_room_device.sql
@@ -1,0 +1,19 @@
+DROP TABLE room_device;
+
+CREATE TABLE room_device (
+    id         BIGSERIAL   PRIMARY KEY,
+    room_id    VARCHAR(50) NOT NULL,
+    device_id  BIGINT      NOT NULL,
+    status     VARCHAR(10) NOT NULL DEFAULT 'OFF',
+    mode       VARCHAR(10) NOT NULL DEFAULT 'AUTO',
+    updated_at TIMESTAMP   NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (room_id)   REFERENCES room(room_id),
+    FOREIGN KEY (device_id) REFERENCES device(id),
+    UNIQUE (room_id, device_id)
+);
+
+INSERT INTO room_device (room_id, device_id, status, mode)
+SELECT r.room_id, d.id, 'OFF', 'AUTO'
+FROM room r
+CROSS JOIN device d;

--- a/src/main/resources/db/migration/V9__create_sensor_type.sql
+++ b/src/main/resources/db/migration/V9__create_sensor_type.sql
@@ -1,0 +1,10 @@
+CREATE TABLE sensor_type (
+    id          BIGSERIAL    PRIMARY KEY,
+    name        VARCHAR(50)  NOT NULL UNIQUE,
+    description VARCHAR(255),
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO sensor_type (name, description) VALUES
+    ('PIR',   'PIR 모션 센서'),
+    ('DHT22', '온습도 센서');


### PR DESCRIPTION
- Add flyway-core and flyway-database-postgresql to build.gradle
- Add application.yml with datasource and Flyway config
- V1-V8: initial schema for room, sensor, device, room_device, sensor_data, control_log, alert_log with seed data
- V9-V16: redesign to integer PKs, extract sensor_type table, composite room_device PK, normalize all FK references to bigint
- V17: add composite indexes on sensor_data, control_log, alert_log for time-range queries per sensor/room