### PR TITLE
[FEAT] Add energy saving rate API

### DIFF
--- a/src/main/java/ac/gachon/iot/IotApplication.java
+++ b/src/main/java/ac/gachon/iot/IotApplication.java
@@ -3,11 +3,13 @@ package ac.gachon.iot;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class IotApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(IotApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(IotApplication.class, args);
+    }
 
 }

--- a/src/main/java/ac/gachon/iot/config/DefaultTimeZoneConfiguration.java
+++ b/src/main/java/ac/gachon/iot/config/DefaultTimeZoneConfiguration.java
@@ -1,0 +1,23 @@
+package ac.gachon.iot.config;
+
+import ac.gachon.iot.properties.TimeZoneProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+@RequiredArgsConstructor
+public class DefaultTimeZoneConfiguration {
+    private final TimeZoneProperties timeZoneProperties;
+
+    @PostConstruct
+    public void defaultTimeZoneInit() {
+        // defaultTimeZone에 대해 전달받은 TimeZoneId로 설정한다
+        // 즉 , Asia/Seoul로 DefaultTimeZone을 설정한다면 , LocalDateTime.now() 할 때 한국 시간으로 출력된다.
+        TimeZone.setDefault(TimeZone.getTimeZone(timeZoneProperties.getTimeZoneId()));
+    }
+
+
+}

--- a/src/main/java/ac/gachon/iot/controller/EnergyController.java
+++ b/src/main/java/ac/gachon/iot/controller/EnergyController.java
@@ -1,6 +1,7 @@
 package ac.gachon.iot.controller;
 
 import ac.gachon.iot.dto.EnergyDailyResponse;
+import ac.gachon.iot.dto.EnergyEfficiencyResponse;
 import ac.gachon.iot.service.EnergyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,8 @@ public class EnergyController {
     }
 
     @GetMapping("/efficiency")
-    public void getEnergyEfficiency() {
+    public EnergyEfficiencyResponse getEnergyEfficiency() {
+        return energyService.findTotalMaxWhPerDay();
     }
+
 }

--- a/src/main/java/ac/gachon/iot/domain/repository/DeviceRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/DeviceRepository.java
@@ -2,8 +2,14 @@ package ac.gachon.iot.domain.repository;
 
 import ac.gachon.iot.domain.entity.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DeviceRepository extends JpaRepository<Device, Long> {
+    @Query("""
+                    select sum(d.powerWatt)
+                    from Device d join RoomDevice r on d.id=r.device.id                             
+            """)
+    Double findTotalMaxWhPerDay();
 }

--- a/src/main/java/ac/gachon/iot/dto/EnergyEfficiencyResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/EnergyEfficiencyResponse.java
@@ -1,0 +1,10 @@
+package ac.gachon.iot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EnergyEfficiencyResponse {
+    private Long efficiency;
+}

--- a/src/main/java/ac/gachon/iot/properties/TimeZoneProperties.java
+++ b/src/main/java/ac/gachon/iot/properties/TimeZoneProperties.java
@@ -1,0 +1,14 @@
+package ac.gachon.iot.properties;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+public class TimeZoneProperties {
+
+    @Value("${timezone.identifier}")
+    private String timeZoneId;
+
+}

--- a/src/main/java/ac/gachon/iot/service/EnergyService.java
+++ b/src/main/java/ac/gachon/iot/service/EnergyService.java
@@ -4,14 +4,17 @@ import ac.gachon.iot.domain.entity.ControlLog;
 import ac.gachon.iot.domain.entity.EnergyDaily;
 import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.domain.repository.ControlLogRepository;
+import ac.gachon.iot.domain.repository.DeviceRepository;
 import ac.gachon.iot.domain.repository.EnergyDailyRepository;
 import ac.gachon.iot.dto.EnergyDailyResponse;
+import ac.gachon.iot.dto.EnergyEfficiencyResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,11 +24,23 @@ public class EnergyService {
 
     private final ControlLogRepository controlLogRepository;
     private final EnergyDailyRepository energyDailyRepository;
+    private final DeviceRepository deviceRepository;
 
     public EnergyDailyResponse findDailyUsage() {
         EnergyDaily energyDaily = getOrCreateToday();
         Double addedWh = calculateAdditional(energyDaily);
         return updateAndReturn(energyDaily, addedWh);
+    }
+
+    public EnergyEfficiencyResponse findTotalMaxWhPerDay() {
+        EnergyDaily energyDaily = getOrCreateToday();
+        Double actualWh = calculateAdditional(energyDaily);
+        Double maxWh = deviceRepository.findTotalMaxWhPerDay();
+
+        double efficiency = (maxWh - actualWh) / maxWh * 100;
+        return EnergyEfficiencyResponse.builder()
+                .efficiency(Math.round(efficiency))
+                .build();
     }
 
 
@@ -36,7 +51,7 @@ public class EnergyService {
                         EnergyDaily.builder()
                                 .date(LocalDate.now())
                                 .totalWh(0.0)
-                                .lastCalculatedAt(OffsetDateTime.now())
+                                .lastCalculatedAt(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC))
                                 .build()));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  jackson:
+    time-zone: UTC
+
   datasource:
     url: jdbc:postgresql://localhost:5432/biot_db
     username: postgres
@@ -9,6 +12,10 @@ spring:
     hibernate:
       ddl-auto: validate
     open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: ${TIMEZONE_IDENTIFIER}
 
   flyway:
     enabled: true
@@ -32,3 +39,6 @@ springdoc:
 jwt:
   secret: ${JWT_SECRET:K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=}
   expiration: 86400000
+
+timezone:
+  identifier: ${TIMEZONE_IDENTIFIER}

--- a/src/main/resources/db/migration/V29__seed_today_control_log.sql
+++ b/src/main/resources/db/migration/V29__seed_today_control_log.sql
@@ -1,0 +1,28 @@
+-- 오늘 날짜 기준 control_log 시드 데이터
+-- 조명: 2시간 30분 전 ON → 1시간 30분 전 OFF (1시간 사용 → 50Wh)
+INSERT INTO control_log (room_id, device_id, action, type, created_at)
+SELECT r.id, d.id, 'ON', 'AUTO', NOW() - INTERVAL '2.5 hours'
+FROM room r, device d
+WHERE r.name = '1층 회의실' AND d.name = '조명';
+
+INSERT INTO control_log (room_id, device_id, action, type, created_at)
+SELECT r.id, d.id, 'OFF', 'AUTO', NOW() - INTERVAL '1.5 hours'
+FROM room r, device d
+WHERE r.name = '1층 회의실' AND d.name = '조명';
+
+-- 에어컨: 2시간 전 ON → 30분 전 OFF (1.5시간 사용 → 2250Wh)
+INSERT INTO control_log (room_id, device_id, action, type, created_at)
+SELECT r.id, d.id, 'ON', 'MANUAL', NOW() - INTERVAL '2 hours'
+FROM room r, device d
+WHERE r.name = '1층 회의실' AND d.name = '에어컨';
+
+INSERT INTO control_log (room_id, device_id, action, type, created_at)
+SELECT r.id, d.id, 'OFF', 'MANUAL', NOW() - INTERVAL '30 minutes'
+FROM room r, device d
+WHERE r.name = '1층 회의실' AND d.name = '에어컨';
+
+-- 조명: 20분 전 ON (현재까지 켜져 있는 상태)
+INSERT INTO control_log (room_id, device_id, action, type, created_at)
+SELECT r.id, d.id, 'ON', 'AUTO', NOW() - INTERVAL '20 minutes'
+FROM room r, device d
+WHERE r.name = '1층 사무실' AND d.name = '조명';

--- a/src/main/resources/db/migration/V30__reset_today_energy_daily.sql
+++ b/src/main/resources/db/migration/V30__reset_today_energy_daily.sql
@@ -1,0 +1,2 @@
+-- 오늘 energy_daily 레코드 삭제 (서버 재시작 시 00:00 UTC 기준으로 재생성되도록)
+DELETE FROM energy_daily WHERE date = CURRENT_DATE;

--- a/src/test/java/ac/gachon/iot/service/EnergyServiceTest.java
+++ b/src/test/java/ac/gachon/iot/service/EnergyServiceTest.java
@@ -1,0 +1,213 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.entity.ControlLog;
+import ac.gachon.iot.domain.entity.Device;
+import ac.gachon.iot.domain.entity.EnergyDaily;
+import ac.gachon.iot.domain.entity.Room;
+import ac.gachon.iot.domain.enums.ControlMode;
+import ac.gachon.iot.domain.enums.DeviceStatus;
+import ac.gachon.iot.domain.repository.ControlLogRepository;
+import ac.gachon.iot.domain.repository.DeviceRepository;
+import ac.gachon.iot.domain.repository.EnergyDailyRepository;
+import ac.gachon.iot.dto.EnergyDailyResponse;
+import ac.gachon.iot.dto.EnergyEfficiencyResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EnergyServiceTest {
+
+    @Mock ControlLogRepository controlLogRepository;
+    @Mock EnergyDailyRepository energyDailyRepository;
+    @Mock DeviceRepository deviceRepository;
+
+    @InjectMocks EnergyService energyService;
+
+    private Room room;
+    private Device light;   // 50W
+    private Device aircon;  // 1500W
+    private OffsetDateTime todayStart;
+
+    @BeforeEach
+    void setUp() {
+        room = mock(Room.class);
+        light = mock(Device.class);
+        given(light.getId()).willReturn(1L);
+        given(light.getPowerWatt()).willReturn(50);
+        aircon = mock(Device.class);
+        given(aircon.getId()).willReturn(2L);
+        given(aircon.getPowerWatt()).willReturn(1500);
+        todayStart = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("오늘 control_log가 없으면 totalWh = 0")
+    void findDailyUsage_noLogs_returnsZero() {
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of());
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyDailyResponse result = energyService.findDailyUsage();
+
+        assertThat(result.getTotalWh()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("조명 1시간 사용 → 0.05 kWh")
+    void findDailyUsage_lightOnOneHour_returns0_05kWh() {
+        OffsetDateTime onTime  = OffsetDateTime.now().minusHours(2);
+        OffsetDateTime offTime = OffsetDateTime.now().minusHours(1);
+
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of(
+                logOf(DeviceStatus.ON,  onTime),
+                logOf(DeviceStatus.OFF, offTime)
+        ));
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyDailyResponse result = energyService.findDailyUsage();
+
+        // 50W × 1h = 50Wh = 0.05 kWh
+        assertThat(result.getTotalWh()).isCloseTo(0.05, org.assertj.core.data.Offset.offset(0.001));
+    }
+
+    @Test
+    @DisplayName("에어컨 1.5시간 사용 → 2.25 kWh")
+    void findDailyUsage_airconOneAndHalfHour_returns2_25kWh() {
+        OffsetDateTime onTime  = OffsetDateTime.now().minusMinutes(90);
+        OffsetDateTime offTime = OffsetDateTime.now();
+
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of(
+                airconLogOf(DeviceStatus.ON,  onTime),
+                airconLogOf(DeviceStatus.OFF, offTime)
+        ));
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyDailyResponse result = energyService.findDailyUsage();
+
+        // 1500W × 1.5h = 2250Wh = 2.25 kWh
+        assertThat(result.getTotalWh()).isCloseTo(2.25, org.assertj.core.data.Offset.offset(0.01));
+    }
+
+    @Test
+    @DisplayName("ON만 있고 OFF 없는 기기 → 현재까지 사용량 계산")
+    void findDailyUsage_onlyOnLog_calculatesUntilNow() {
+        OffsetDateTime onTime = OffsetDateTime.now().minusMinutes(30);
+
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of(
+                logOf(DeviceStatus.ON, onTime)
+        ));
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyDailyResponse result = energyService.findDailyUsage();
+
+        // 50W × 0.5h = 25Wh = 0.025 kWh
+        assertThat(result.getTotalWh()).isCloseTo(0.025, org.assertj.core.data.Offset.offset(0.002));
+    }
+
+    @Test
+    @DisplayName("energy_daily 레코드 없으면 새로 생성 후 계산")
+    void findDailyUsage_noEnergyDaily_createsAndCalculates() {
+        EnergyDaily newRecord = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.empty());
+        given(energyDailyRepository.save(any())).willReturn(newRecord);
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of());
+
+        EnergyDailyResponse result = energyService.findDailyUsage();
+
+        assertThat(result.getTotalWh()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("사용량 0이면 절감률 100%")
+    void findEfficiency_noUsage_returns100() {
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of());
+        given(deviceRepository.findTotalMaxWhPerDay()).willReturn(1550.0); // 50 + 1500
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyEfficiencyResponse result = energyService.findTotalMaxWhPerDay();
+
+        assertThat(result.getEfficiency()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("조명 1시간 사용 시 절감률 계산")
+    void findEfficiency_lightOneHour_correctEfficiency() {
+        OffsetDateTime onTime  = OffsetDateTime.now().minusHours(2);
+        OffsetDateTime offTime = OffsetDateTime.now().minusHours(1);
+
+        EnergyDaily today = energyDailyOf(0.0, todayStart);
+        given(energyDailyRepository.findByDate(LocalDate.now())).willReturn(Optional.of(today));
+        given(controlLogRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of(
+                logOf(DeviceStatus.ON,  onTime),
+                logOf(DeviceStatus.OFF, offTime)
+        ));
+        given(deviceRepository.findTotalMaxWhPerDay()).willReturn(1550.0); // 50 + 1500
+        given(energyDailyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EnergyEfficiencyResponse result = energyService.findTotalMaxWhPerDay();
+
+        // actualWh=50, maxWh=1550 → (1550-50)/1550*100 = 96.77 → round → 97%
+        assertThat(result.getEfficiency()).isEqualTo(97L);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private EnergyDaily energyDailyOf(double totalWh, OffsetDateTime lastCalculatedAt) {
+        return EnergyDaily.builder()
+                .id(1L)
+                .date(LocalDate.now())
+                .totalWh(totalWh)
+                .lastCalculatedAt(lastCalculatedAt)
+                .build();
+    }
+
+    private ControlLog logOf(DeviceStatus action, OffsetDateTime createdAt) {
+        return ControlLog.builder()
+                .id(1L)
+                .room(room)
+                .device(light)
+                .action(action)
+                .type(ControlMode.MANUAL)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    private ControlLog airconLogOf(DeviceStatus action, OffsetDateTime createdAt) {
+        return ControlLog.builder()
+                .id(2L)
+                .room(room)
+                .device(aircon)
+                .action(action)
+                .type(ControlMode.MANUAL)
+                .createdAt(createdAt)
+                .build();
+    }
+}


### PR DESCRIPTION
Closes #6

## Summary
- implement GET /v1/energy/efficiency with saving rate calculation
- fix getOrCreateToday to use start of day UTC as lastCalculatedAt
- add timezone config via TimeZoneProperties and DefaultTimeZoneConfiguration
- add V29 seed and V30 reset migration for energy daily testing
- add EnergyService unit tests (7 cases)

## Test plan
- [ ] 관련 단위 테스트 통과 확인
- [ ] API 응답 확인 (Swagger or Postman)