### PR TITLE
[FEAT] Add room list with devices API

### DIFF
--- a/src/main/java/ac/gachon/iot/controller/RoomController.java
+++ b/src/main/java/ac/gachon/iot/controller/RoomController.java
@@ -1,0 +1,23 @@
+package ac.gachon.iot.controller;
+
+import ac.gachon.iot.dto.AllRoomsResponse;
+import ac.gachon.iot.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @GetMapping("")
+    public List<AllRoomsResponse> getAllRooms() {
+        return roomService.findAllRooms();
+    }
+}

--- a/src/main/java/ac/gachon/iot/domain/entity/Room.java
+++ b/src/main/java/ac/gachon/iot/domain/entity/Room.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -18,4 +19,7 @@ public class Room {
     private String name;
 
     private Integer floor;
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomDevice> roomDevices;
 }

--- a/src/main/java/ac/gachon/iot/domain/repository/RoomRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/RoomRepository.java
@@ -1,11 +1,17 @@
 package ac.gachon.iot.domain.repository;
 
-import ac.gachon.iot.domain.entity.Device;
 import ac.gachon.iot.domain.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
+
     
+    @Query("select distinct r from Room r join  fetch r.roomDevices rd join fetch rd.device")
+    List<Room> findAllWithDevices();
+
 }

--- a/src/main/java/ac/gachon/iot/dto/AllRoomsResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/AllRoomsResponse.java
@@ -1,0 +1,16 @@
+package ac.gachon.iot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AllRoomsResponse {
+    private Long roomId;
+    private String roomName;
+    private List<DeviceStatusResponse> devices;
+}

--- a/src/main/java/ac/gachon/iot/dto/DeviceStatusResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/DeviceStatusResponse.java
@@ -1,0 +1,14 @@
+package ac.gachon.iot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class DeviceStatusResponse {
+
+    private Long deviceId;
+    private String deviceType;
+    private String status;
+}

--- a/src/main/java/ac/gachon/iot/service/RoomService.java
+++ b/src/main/java/ac/gachon/iot/service/RoomService.java
@@ -1,0 +1,40 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.entity.Device;
+import ac.gachon.iot.domain.entity.Room;
+import ac.gachon.iot.domain.entity.RoomDevice;
+import ac.gachon.iot.domain.repository.RoomRepository;
+import ac.gachon.iot.dto.AllRoomsResponse;
+import ac.gachon.iot.dto.DeviceStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    public List<AllRoomsResponse> findAllRooms() {
+        
+        List<Room> allRooms = roomRepository.findAllWithDevices();
+
+        return allRooms.stream().map(room -> AllRoomsResponse.builder()
+                .roomId(room.getId())
+                .roomName(room.getName())
+                .devices(room.getRoomDevices().stream()
+                        .map(rd -> DeviceStatusResponse.builder()
+                                .deviceId(rd.getDevice().getId())
+                                .deviceType(rd.getDevice().getName())
+                                .status(rd.getStatus().name())
+                                .build())
+                        .toList())
+                .build()
+        ).toList();
+
+    }
+
+}

--- a/src/test/java/ac/gachon/iot/service/RoomServiceTest.java
+++ b/src/test/java/ac/gachon/iot/service/RoomServiceTest.java
@@ -1,0 +1,121 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.entity.Device;
+import ac.gachon.iot.domain.entity.Room;
+import ac.gachon.iot.domain.entity.RoomDevice;
+import ac.gachon.iot.domain.enums.DeviceStatus;
+import ac.gachon.iot.domain.repository.RoomRepository;
+import ac.gachon.iot.dto.AllRoomsResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class RoomServiceTest {
+
+    @Mock RoomRepository roomRepository;
+
+    @InjectMocks RoomService roomService;
+
+    @Test
+    @DisplayName("방 목록과 기기 정보를 정상 반환한다")
+    void findAllRooms_normalCase() {
+        Device device = mock(Device.class);
+        given(device.getId()).willReturn(1L);
+        given(device.getName()).willReturn("에어컨");
+
+        RoomDevice roomDevice = mock(RoomDevice.class);
+        given(roomDevice.getDevice()).willReturn(device);
+        given(roomDevice.getStatus()).willReturn(DeviceStatus.ON);
+
+        Room room = mock(Room.class);
+        given(room.getId()).willReturn(10L);
+        given(room.getName()).willReturn("거실");
+        given(room.getRoomDevices()).willReturn(List.of(roomDevice));
+
+        given(roomRepository.findAllWithDevices()).willReturn(List.of(room));
+
+        List<AllRoomsResponse> result = roomService.findAllRooms();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRoomId()).isEqualTo(10L);
+        assertThat(result.get(0).getRoomName()).isEqualTo("거실");
+        assertThat(result.get(0).getDevices()).hasSize(1);
+        assertThat(result.get(0).getDevices().get(0).getDeviceId()).isEqualTo(1L);
+        assertThat(result.get(0).getDevices().get(0).getDeviceType()).isEqualTo("에어컨");
+        assertThat(result.get(0).getDevices().get(0).getStatus()).isEqualTo("ON");
+    }
+
+    @Test
+    @DisplayName("방이 없으면 빈 리스트를 반환한다")
+    void findAllRooms_noRooms_returnsEmptyList() {
+        given(roomRepository.findAllWithDevices()).willReturn(List.of());
+
+        List<AllRoomsResponse> result = roomService.findAllRooms();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기기가 없는 방이면 devices가 빈 리스트이다")
+    void findAllRooms_roomWithNoDevices_returnsEmptyDevices() {
+        Room room = mock(Room.class);
+        given(room.getId()).willReturn(20L);
+        given(room.getName()).willReturn("창고");
+        given(room.getRoomDevices()).willReturn(List.of());
+
+        given(roomRepository.findAllWithDevices()).willReturn(List.of(room));
+
+        List<AllRoomsResponse> result = roomService.findAllRooms();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getDevices()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 방과 여러 기기를 모두 반환한다")
+    void findAllRooms_multipleRoomsAndDevices() {
+        Device light = mock(Device.class);
+        given(light.getId()).willReturn(1L);
+        given(light.getName()).willReturn("조명");
+
+        Device aircon = mock(Device.class);
+        given(aircon.getId()).willReturn(2L);
+        given(aircon.getName()).willReturn("에어컨");
+
+        RoomDevice rd1 = mock(RoomDevice.class);
+        given(rd1.getDevice()).willReturn(light);
+        given(rd1.getStatus()).willReturn(DeviceStatus.ON);
+
+        RoomDevice rd2 = mock(RoomDevice.class);
+        given(rd2.getDevice()).willReturn(aircon);
+        given(rd2.getStatus()).willReturn(DeviceStatus.OFF);
+
+        Room room1 = mock(Room.class);
+        given(room1.getId()).willReturn(1L);
+        given(room1.getName()).willReturn("거실");
+        given(room1.getRoomDevices()).willReturn(List.of(rd1, rd2));
+
+        Room room2 = mock(Room.class);
+        given(room2.getId()).willReturn(2L);
+        given(room2.getName()).willReturn("침실");
+        given(room2.getRoomDevices()).willReturn(List.of(rd1));
+
+        given(roomRepository.findAllWithDevices()).willReturn(List.of(room1, room2));
+
+        List<AllRoomsResponse> result = roomService.findAllRooms();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getDevices()).hasSize(2);
+        assertThat(result.get(1).getDevices()).hasSize(1);
+    }
+}


### PR DESCRIPTION
Closes #10

## Summary
- add GET /v1/rooms endpoint returning all rooms with their devices
- add RoomController, RoomService, AllRoomsResponse, DeviceStatusResponse
- add OneToMany roomDevices relation to Room entity
- add findAllWithDevices JPQL fetch join query in RoomRepository
- test normal case returning rooms with devices
- test empty room list returns empty list
- test room with no devices returns empty devices
- test multiple rooms and devices mapping

## Test plan
- [x] 관련 단위 테스트 통과 확인
- [x] API 응답 확인 (Swagger or Postman)