### PR TITLE
[FEAT] Add room latest sensor data API

### DIFF
--- a/src/main/java/ac/gachon/iot/controller/RoomController.java
+++ b/src/main/java/ac/gachon/iot/controller/RoomController.java
@@ -1,9 +1,12 @@
 package ac.gachon.iot.controller;
 
 import ac.gachon.iot.dto.AllRoomsResponse;
+import ac.gachon.iot.dto.RoomSensorLatestResponse;
 import ac.gachon.iot.service.RoomService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +22,13 @@ public class RoomController {
     @GetMapping("")
     public List<AllRoomsResponse> getAllRooms() {
         return roomService.findAllRooms();
+    }
+
+    @GetMapping("{roomId}/sensors/latest")
+    public RoomSensorLatestResponse getLatestSensorsByRoom(@Parameter(description = "방 ID", required = true)
+                                                           @PathVariable Long roomId) {
+        return roomService.findLatestSensorsByRoom(roomId);
+
+
     }
 }

--- a/src/main/java/ac/gachon/iot/domain/repository/SensorDataRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/SensorDataRepository.java
@@ -3,6 +3,7 @@ package ac.gachon.iot.domain.repository;
 import ac.gachon.iot.domain.entity.SensorData;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +13,21 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
 
     @Query("select s from SensorData s where s.createdAt=(select max(s2.createdAt) from SensorData s2 where s2.sensor=s.sensor)")
     List<SensorData> findAllLatest();
+
+    @Query("""
+                        select sd
+                        from SensorData sd
+                                    join fetch sd.sensor s
+                                    join fetch s.sensorType
+                                    join fetch s.room
+                        where s.room.id=:roomId
+                        and sd.createdAt=(
+                             select max(sd2.createdAt)
+                             from SensorData  sd2
+                             where sd2.sensor.id=s.id
+            )
+""")
+    List<SensorData> findLatestsSensorsByRoom(@Param("roomId") Long roomId);
 
 }
 

--- a/src/main/java/ac/gachon/iot/dto/RoomSensorLatestResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/RoomSensorLatestResponse.java
@@ -1,0 +1,15 @@
+package ac.gachon.iot.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RoomSensorLatestResponse {
+    private Long roomId;
+    private String roomName;
+    private List<SensorLatestResponse> sensors;
+}

--- a/src/main/java/ac/gachon/iot/dto/SensorLatestResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/SensorLatestResponse.java
@@ -1,0 +1,16 @@
+package ac.gachon.iot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class SensorLatestResponse {
+    private Long sensorId;
+    private String sensorType;
+    private BigDecimal temperature;
+    private BigDecimal humidity;
+    private Short motion;
+}

--- a/src/main/java/ac/gachon/iot/service/RoomService.java
+++ b/src/main/java/ac/gachon/iot/service/RoomService.java
@@ -1,15 +1,17 @@
 package ac.gachon.iot.service;
 
-import ac.gachon.iot.domain.entity.Device;
 import ac.gachon.iot.domain.entity.Room;
-import ac.gachon.iot.domain.entity.RoomDevice;
+import ac.gachon.iot.domain.entity.SensorData;
 import ac.gachon.iot.domain.repository.RoomRepository;
+import ac.gachon.iot.domain.repository.SensorDataRepository;
 import ac.gachon.iot.dto.AllRoomsResponse;
 import ac.gachon.iot.dto.DeviceStatusResponse;
+import ac.gachon.iot.dto.RoomSensorLatestResponse;
+import ac.gachon.iot.dto.SensorLatestResponse;
+import ac.gachon.iot.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,9 +19,10 @@ import java.util.List;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final SensorDataRepository sensorDataRepository;
 
     public List<AllRoomsResponse> findAllRooms() {
-        
+
         List<Room> allRooms = roomRepository.findAllWithDevices();
 
         return allRooms.stream().map(room -> AllRoomsResponse.builder()
@@ -35,6 +38,27 @@ public class RoomService {
                 .build()
         ).toList();
 
+    }
+
+
+    public RoomSensorLatestResponse findLatestSensorsByRoom(Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 방입니다. id=" + roomId));
+
+        List<SensorData> sensorDataByRoom = sensorDataRepository.findLatestsSensorsByRoom(roomId);
+
+        return RoomSensorLatestResponse.builder()
+                .roomId(roomId)
+                .roomName(room.getName())
+                .sensors(sensorDataByRoom.stream().map(sensorData -> SensorLatestResponse.builder()
+                                .sensorId(sensorData.getSensor().getId())
+                                .sensorType(sensorData.getSensor().getSensorType().getName())
+                                .humidity(sensorData.getHumidity())
+                                .motion(sensorData.getMotion())
+                                .temperature(sensorData.getTemperature())
+                                .build())
+                        .toList())
+                .build();
     }
 
 }

--- a/src/test/java/ac/gachon/iot/service/RoomServiceTest.java
+++ b/src/test/java/ac/gachon/iot/service/RoomServiceTest.java
@@ -1,11 +1,12 @@
 package ac.gachon.iot.service;
 
-import ac.gachon.iot.domain.entity.Device;
-import ac.gachon.iot.domain.entity.Room;
-import ac.gachon.iot.domain.entity.RoomDevice;
+import ac.gachon.iot.domain.entity.*;
 import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.domain.repository.RoomRepository;
+import ac.gachon.iot.domain.repository.SensorDataRepository;
 import ac.gachon.iot.dto.AllRoomsResponse;
+import ac.gachon.iot.dto.RoomSensorLatestResponse;
+import ac.gachon.iot.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,9 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -23,6 +27,7 @@ import static org.mockito.Mockito.mock;
 class RoomServiceTest {
 
     @Mock RoomRepository roomRepository;
+    @Mock SensorDataRepository sensorDataRepository;
 
     @InjectMocks RoomService roomService;
 
@@ -79,6 +84,60 @@ class RoomServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getDevices()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 roomId로 조회하면 NotFoundException 발생")
+    void findLatestSensorsByRoom_roomNotFound_throwsNotFoundException() {
+        given(roomRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.findLatestSensorsByRoom(999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("999");
+    }
+
+    @Test
+    @DisplayName("방의 최신 센서 데이터를 정상 반환한다")
+    void findLatestSensorsByRoom_normalCase() {
+        Room room = mock(Room.class);
+        given(room.getName()).willReturn("거실");
+        given(roomRepository.findById(1L)).willReturn(Optional.of(room));
+
+        SensorType sensorType = mock(SensorType.class);
+        given(sensorType.getName()).willReturn("DHT22");
+
+        Sensor sensor = mock(Sensor.class);
+        given(sensor.getId()).willReturn(1L);
+        given(sensor.getSensorType()).willReturn(sensorType);
+
+        SensorData sensorData = mock(SensorData.class);
+        given(sensorData.getSensor()).willReturn(sensor);
+        given(sensorData.getTemperature()).willReturn(BigDecimal.valueOf(24.5));
+        given(sensorData.getHumidity()).willReturn(BigDecimal.valueOf(60.0));
+        given(sensorData.getMotion()).willReturn(null);
+
+        given(sensorDataRepository.findLatestsSensorsByRoom(1L)).willReturn(List.of(sensorData));
+
+        RoomSensorLatestResponse result = roomService.findLatestSensorsByRoom(1L);
+
+        assertThat(result.getRoomId()).isEqualTo(1L);
+        assertThat(result.getRoomName()).isEqualTo("거실");
+        assertThat(result.getSensors()).hasSize(1);
+        assertThat(result.getSensors().get(0).getSensorType()).isEqualTo("DHT22");
+        assertThat(result.getSensors().get(0).getTemperature()).isEqualTo(BigDecimal.valueOf(24.5));
+    }
+
+    @Test
+    @DisplayName("센서 데이터가 없는 방이면 sensors가 빈 리스트이다")
+    void findLatestSensorsByRoom_noSensorData_returnsEmptySensors() {
+        Room room = mock(Room.class);
+        given(room.getName()).willReturn("창고");
+        given(roomRepository.findById(2L)).willReturn(Optional.of(room));
+        given(sensorDataRepository.findLatestsSensorsByRoom(2L)).willReturn(List.of());
+
+        RoomSensorLatestResponse result = roomService.findLatestSensorsByRoom(2L);
+
+        assertThat(result.getSensors()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Closes #12

## Summary
- add GET /v1/rooms/{roomId}/sensors/latest endpoint
- add findLatestSensorsByRoom query with join fetch for sensor and sensorType
- add NotFoundException when roomId does not exist
- add RoomSensorLatestResponse and SensorLatestResponse DTOs
- add unit tests for findLatestSensorsByRoom

## Test plan
- [x] 관련 단위 테스트 통과 확인
- [x] API 응답 확인 (Swagger or Postman)