### PR TITLE
[FEAT] Add MQTT subscriber to process incoming IoT sensor data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
     // Observability
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    //MQTT
+    implementation 'org.springframework.boot:spring-boot-starter-integration'
+    implementation 'org.springframework.integration:spring-integration-mqtt'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,15 @@ services:
       - loki
     restart: unless-stopped
 
+  mosquitto:
+    image: eclipse-mosquitto:2.0
+    container_name: mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./monitoring/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    restart: unless-stopped
+
 volumes:
   loki_data:
   grafana_data:

--- a/monitoring/mosquitto/mosquitto.conf
+++ b/monitoring/mosquitto/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/src/main/java/ac/gachon/iot/config/MqttConfig.java
+++ b/src/main/java/ac/gachon/iot/config/MqttConfig.java
@@ -1,0 +1,62 @@
+package ac.gachon.iot.config;
+
+import ac.gachon.iot.mqtt.MqttMessageHandler;
+import ac.gachon.iot.properties.MqttProperties;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
+import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
+import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
+import org.springframework.integration.mqtt.support.DefaultPahoMessageConverter;
+
+@Configuration
+@RequiredArgsConstructor
+public class MqttConfig {
+
+    private final MqttProperties mqttProperties;
+    private final MqttMessageHandler mqttMessageHandler;
+
+    @Bean
+    public MqttPahoClientFactory mqttClientFactory() {
+        DefaultMqttPahoClientFactory factory = new DefaultMqttPahoClientFactory();
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setServerURIs(new String[]{mqttProperties.getBrokerUrl()});
+        options.setCleanSession(mqttProperties.isCleanSession());
+        options.setConnectionTimeout(mqttProperties.getConnectionTimeout());
+        options.setKeepAliveInterval(mqttProperties.getKeepAliveInterval());
+        options.setAutomaticReconnect(true);
+
+        String username = mqttProperties.getUsername();
+        if (username != null && !username.isBlank()) {
+            options.setUserName(username);
+            options.setPassword(mqttProperties.getPassword().toCharArray());
+        }
+
+        factory.setConnectionOptions(options);
+        return factory;
+    }
+
+    @Bean
+    public MqttPahoMessageDrivenChannelAdapter mqttInboundAdapter() {
+        MqttPahoMessageDrivenChannelAdapter adapter = new MqttPahoMessageDrivenChannelAdapter(
+                mqttProperties.getClientId(),
+                mqttClientFactory(),
+                mqttProperties.getTopic()
+        );
+        adapter.setCompletionTimeout(5000);
+        adapter.setConverter(new DefaultPahoMessageConverter());
+        adapter.setQos(mqttProperties.getQos());
+        return adapter;
+    }
+
+    @Bean
+    public IntegrationFlow mqttInboundFlow() {
+        return IntegrationFlow
+                .from(mqttInboundAdapter())
+                .handle(mqttMessageHandler, "handle")
+                .get();
+    }
+}

--- a/src/main/java/ac/gachon/iot/domain/entity/AlertLog.java
+++ b/src/main/java/ac/gachon/iot/domain/entity/AlertLog.java
@@ -26,4 +26,11 @@ public class AlertLog {
 
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
+    public static AlertLog create(Sensor sensor, AlertType type, String message) {
+        AlertLog log = new AlertLog();
+        log.sensor = sensor;
+        log.type = type;
+        log.message = message;
+        return log;
+    }
 }

--- a/src/main/java/ac/gachon/iot/domain/entity/SensorData.java
+++ b/src/main/java/ac/gachon/iot/domain/entity/SensorData.java
@@ -1,9 +1,9 @@
 package ac.gachon.iot.domain.entity;
 
 import ac.gachon.iot.domain.enums.SensorStatus;
+import ac.gachon.iot.dto.MqttSensorPayload;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -31,9 +31,17 @@ public class SensorData {
     @Column(nullable = false)
     private SensorStatus status;
 
-    @CreatedDate
     private OffsetDateTime createdAt;
 
-
+    public static SensorData create(Sensor sensor, MqttSensorPayload payload, SensorStatus status) {
+        SensorData data = new SensorData();
+        data.sensor = sensor;
+        data.temperature = payload.temperature();
+        data.humidity = payload.humidity();
+        data.motion = payload.motion();
+        data.status = status;
+        data.createdAt = OffsetDateTime.now();
+        return data;
+    }
 }
 

--- a/src/main/java/ac/gachon/iot/domain/repository/SensorRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/SensorRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SensorRepository extends JpaRepository<Sensor, Long> {
 //    List<SensorData> findTopBySensorOrderByCreatedAt();
+
+    Optional<Sensor> findByIdentifier(String identifier);
 }
+

--- a/src/main/java/ac/gachon/iot/dto/MqttSensorPayload.java
+++ b/src/main/java/ac/gachon/iot/dto/MqttSensorPayload.java
@@ -1,0 +1,11 @@
+package ac.gachon.iot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MqttSensorPayload(
+        BigDecimal temperature,
+        BigDecimal humidity,
+        Short motion
+) {}

--- a/src/main/java/ac/gachon/iot/exception/MqttMessageProcessingException.java
+++ b/src/main/java/ac/gachon/iot/exception/MqttMessageProcessingException.java
@@ -1,0 +1,7 @@
+package ac.gachon.iot.exception;
+
+public class MqttMessageProcessingException extends RuntimeException {
+    public MqttMessageProcessingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ac/gachon/iot/mqtt/MqttMessageHandler.java
+++ b/src/main/java/ac/gachon/iot/mqtt/MqttMessageHandler.java
@@ -1,0 +1,42 @@
+package ac.gachon.iot.mqtt;
+
+import ac.gachon.iot.dto.MqttSensorPayload;
+import ac.gachon.iot.exception.MqttMessageProcessingException;
+import ac.gachon.iot.service.SensorDataIngestionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MqttMessageHandler {
+
+    private final SensorDataIngestionService sensorDataIngestionService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void handle(Message<String> message) {
+        String topic = message.getHeaders().get("mqtt_receivedTopic", String.class);
+        String payload = message.getPayload();
+
+        log.debug("MQTT message received. topic={}, payload={}", topic, payload);
+
+        try {
+            String identifier = extractIdentifier(topic);
+            MqttSensorPayload sensorPayload = objectMapper.readValue(payload, MqttSensorPayload.class);
+            sensorDataIngestionService.ingest(identifier, sensorPayload);
+        } catch (Exception e) {
+            log.error("Failed to process MQTT message. topic={}, payload={}", topic, payload, e);
+        }
+    }
+
+    private String extractIdentifier(String topic) {
+        String[] parts = topic.split("/");
+        if (parts.length < 3) {
+            throw new MqttMessageProcessingException("Invalid topic format: " + topic);
+        }
+        return parts[1];
+    }
+}

--- a/src/main/java/ac/gachon/iot/properties/MqttProperties.java
+++ b/src/main/java/ac/gachon/iot/properties/MqttProperties.java
@@ -1,0 +1,37 @@
+package ac.gachon.iot.properties;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+public class MqttProperties {
+
+    @Value("${mqtt.broker-url}")
+    private String brokerUrl;
+
+    @Value("${mqtt.client-id}")
+    private String clientId;
+
+    @Value("${mqtt.username:}")
+    private String username;
+
+    @Value("${mqtt.password:}")
+    private String password;
+
+    @Value("${mqtt.topic}")
+    private String topic;
+
+    @Value("${mqtt.qos:1}")
+    private int qos;
+
+    @Value("${mqtt.connection-timeout:10}")
+    private int connectionTimeout;
+
+    @Value("${mqtt.keep-alive-interval:60}")
+    private int keepAliveInterval;
+
+    @Value("${mqtt.clean-session:true}")
+    private boolean cleanSession;
+}

--- a/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
+++ b/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
@@ -1,0 +1,92 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.entity.AlertLog;
+import ac.gachon.iot.domain.entity.Sensor;
+import ac.gachon.iot.domain.entity.SensorData;
+import ac.gachon.iot.domain.enums.AlertType;
+import ac.gachon.iot.domain.enums.SensorStatus;
+import ac.gachon.iot.domain.repository.AlertLogRepository;
+import ac.gachon.iot.domain.repository.SensorDataRepository;
+import ac.gachon.iot.domain.repository.SensorRepository;
+import ac.gachon.iot.dto.MqttSensorPayload;
+import ac.gachon.iot.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SensorDataIngestionService {
+
+    private final SensorRepository sensorRepository;
+    private final SensorDataRepository sensorDataRepository;
+    private final AlertLogRepository alertLogRepository;
+
+    @Value("${sensor.threshold.temperature.max:30.0}")
+    private BigDecimal temperatureMax;
+
+    @Value("${sensor.threshold.humidity.max:80.0}")
+    private BigDecimal humidityMax;
+
+    @Transactional
+    public void ingest(String identifier, MqttSensorPayload payload) {
+        Sensor sensor = sensorRepository.findByIdentifier(identifier)
+                .orElseThrow(() -> new NotFoundException("Sensor not found: " + identifier));
+
+        SensorStatus status = determineStatus(payload);
+        sensorDataRepository.save(SensorData.create(sensor, payload, status));
+
+        if (status == SensorStatus.ANOMALY) {
+            AlertType alertType = resolveAlertType(payload);
+            String message = resolveAlertMessage(alertType, payload);
+            alertLogRepository.save(AlertLog.create(sensor, alertType, message));
+            log.warn("Anomaly detected. identifier={}, alertType={}", identifier, alertType);
+        }
+
+        log.info("SensorData ingested. identifier={}, status={}", identifier, status);
+    }
+
+    private SensorStatus determineStatus(MqttSensorPayload payload) {
+        if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
+            return SensorStatus.ANOMALY;
+        }
+        if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
+            return SensorStatus.ANOMALY;
+        }
+        if (payload.motion() != null && payload.motion() == 1 && isNightTime()) {
+            return SensorStatus.ANOMALY;
+        }
+        return SensorStatus.NORMAL;
+    }
+
+    private boolean isNightTime() {
+        int hour = OffsetDateTime.now().getHour();
+        return hour >= 22 || hour < 6;
+    }
+
+    private AlertType resolveAlertType(MqttSensorPayload payload) {
+        if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
+            return AlertType.HIGH_TEMP;
+        }
+        if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
+            return AlertType.HIGH_HUMIDITY;
+        }
+        return AlertType.NIGHT_MOTION;
+    }
+
+    private String resolveAlertMessage(AlertType alertType, MqttSensorPayload payload) {
+        return switch (alertType) {
+            case HIGH_TEMP -> "온도가 임계값(%.1f°C)을 초과했습니다. 현재: %s°C"
+                    .formatted(temperatureMax, payload.temperature());
+            case HIGH_HUMIDITY -> "습도가 임계값(%.1f%%)을 초과했습니다. 현재: %s%%"
+                    .formatted(humidityMax, payload.humidity());
+            case NIGHT_MOTION -> "야간 모션이 감지되었습니다.";
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,24 @@ jwt:
 timezone:
   identifier: ${TIMEZONE_IDENTIFIER}
 
+mqtt:
+  broker-url: ${MQTT_BROKER_URL:tcp://mosquitto:1883}
+  client-id: ${MQTT_CLIENT_ID:iot-backend-subscriber}
+  username: ${MQTT_USERNAME:}
+  password: ${MQTT_PASSWORD:}
+  topic: sensors/+/data
+  qos: 1
+  connection-timeout: 10
+  keep-alive-interval: 60
+  clean-session: true
+
+sensor:
+  threshold:
+    temperature:
+      max: 30.0
+    humidity:
+      max: 80.0
+    
 management:
   endpoints:
     web:
@@ -57,3 +75,5 @@ management:
   metrics:
     tags:
       application: ${spring.application.name:iot-backend}
+
+


### PR DESCRIPTION
Closes #16

## Summary
- add Spring Integration MQTT + Eclipse Paho dependencies
- add MqttProperties for broker connection configuration
- add MqttConfig to set up MQTT inbound flow via Spring Integration
- add MqttMessageHandler to parse topic and delegate to service
- add SensorDataIngestionService with threshold-based anomaly detection
- add SensorData.create() and AlertLog.create() static factory methods
- add SensorRepository.findByIdentifier() for sensor lookup by topic
- add MqttSensorPayload record for JSON deserialization
- add Mosquitto broker service to docker-compose.yml
- update application.yml with mqtt and sensor threshold config

## Test plan
- [x] 관련 단위 테스트 통과 확인
- [x] API 응답 확인 (Swagger or Postman)