### PR TITLE
FEAT(dashboard): add WebSocket real-time dashboard with auto-control and auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     //MQTT
     implementation 'org.springframework.boot:spring-boot-starter-integration'
     implementation 'org.springframework.integration:spring-integration-mqtt'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // Password encoding
+    implementation 'org.springframework.security:spring-security-crypto'
+
     //MQTT
     implementation 'org.springframework.boot:spring-boot-starter-integration'
     implementation 'org.springframework.integration:spring-integration-mqtt'

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>스마트 빌딩 관제 대시보드</title>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg-primary: #ffffff;
+      --bg-secondary: #f5f5f4;
+      --bg-tertiary: #f0efed;
+      --bg-info: #e6f1fb;
+      --bg-success: #eaf3de;
+      --bg-warning: #faeeda;
+      --bg-danger: #fcebeb;
+      --text-primary: #1a1a18;
+      --text-secondary: #5f5e5a;
+      --text-info: #185fa5;
+      --text-success: #3b6d11;
+      --text-warning: #854f0b;
+      --text-danger: #a32d2d;
+      --border: rgba(0,0,0,0.12);
+      --border-info: rgba(24,95,165,0.3);
+      --radius-md: 8px;
+      --radius-lg: 12px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1c1c1a;
+        --bg-secondary: #252523;
+        --bg-tertiary: #2c2c2a;
+        --bg-info: #0c2a4a;
+        --bg-success: #162a08;
+        --bg-warning: #2a1a04;
+        --bg-danger: #2a0e0e;
+        --text-primary: #e8e6df;
+        --text-secondary: #9c9a92;
+        --text-info: #85b7eb;
+        --text-success: #97c459;
+        --text-warning: #fac775;
+        --text-danger: #f09595;
+        --border: rgba(255,255,255,0.1);
+        --border-info: rgba(133,183,235,0.3);
+      }
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg-tertiary);
+      color: var(--text-primary);
+      min-height: 100vh;
+      padding: 24px;
+    }
+    .dashboard { max-width: 900px; margin: 0 auto; }
+    .topbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
+    .topbar h1 { font-size: 18px; font-weight: 500; }
+    .summary-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 10px; margin-bottom: 1.5rem; }
+    .summary-card { background: var(--bg-secondary); border-radius: var(--radius-md); padding: 1rem; }
+    .summary-card .label { font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; }
+    .summary-card .value { font-size: 22px; font-weight: 500; }
+    .summary-card .value.danger { color: var(--text-danger); }
+    .summary-card .value.success { color: var(--text-success); }
+    .main-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 1.5rem; }
+    .card { background: var(--bg-primary); border: 0.5px solid var(--border); border-radius: var(--radius-lg); padding: 1rem 1.25rem; }
+    .card-title { font-size: 13px; font-weight: 500; color: var(--text-secondary); margin-bottom: 1rem; }
+    .room-list { display: flex; flex-direction: column; gap: 8px; }
+    .room-item { background: var(--bg-secondary); border-radius: var(--radius-md); padding: 10px 12px; }
+    .room-top { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 10px; }
+    .room-name { font-size: 14px; font-weight: 500; }
+    .room-sub { font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
+    .room-bottom { display: flex; gap: 6px; }
+    .badge { font-size: 11px; padding: 3px 8px; border-radius: var(--radius-md); font-weight: 500; }
+    .badge.normal { background: var(--bg-success); color: var(--text-success); }
+    .badge.anomaly { background: var(--bg-danger); color: var(--text-danger); }
+    .badge.empty { background: var(--bg-secondary); color: var(--text-secondary); border: 0.5px solid var(--border); }
+    .ctrl-btn {
+      font-size: 12px; padding: 5px 12px; border-radius: var(--radius-md);
+      border: 0.5px solid var(--border); cursor: pointer; font-weight: 500;
+      background: var(--bg-primary); color: var(--text-secondary); transition: all 0.15s;
+    }
+    .ctrl-btn:hover { background: var(--bg-secondary); }
+    .ctrl-btn.on { background: var(--bg-info); color: var(--text-info); border-color: var(--border-info); }
+    .alert-list { display: flex; flex-direction: column; gap: 8px; height: 320px; overflow-y: auto; }
+    .alert-item { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; background: var(--bg-secondary); border-radius: var(--radius-md); }
+    .alert-dot { width: 8px; height: 8px; border-radius: 50%; margin-top: 4px; flex-shrink: 0; }
+    .alert-dot.danger { background: var(--text-danger); }
+    .alert-dot.warning { background: var(--text-warning); }
+    .alert-title { font-size: 13px; font-weight: 500; }
+    .alert-sub { font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
+    .energy-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 10px; margin-bottom: 1.5rem; }
+    .energy-card { background: var(--bg-secondary); border-radius: var(--radius-md); padding: 1rem; }
+    .energy-label { font-size: 12px; color: var(--text-secondary); margin-bottom: 4px; }
+    .energy-value { font-size: 20px; font-weight: 500; }
+    .energy-sub { font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
+    .progress-bar { height: 4px; background: var(--border); border-radius: 2px; margin-top: 8px; overflow: hidden; }
+    .progress-fill { height: 100%; border-radius: 2px; }
+    .log-list { display: flex; flex-direction: column; gap: 6px; height: 258px; overflow-y: auto; }
+    .log-item { display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; background: var(--bg-secondary); border-radius: var(--radius-md); }
+    .log-text { font-size: 13px; }
+    .log-right { display: flex; gap: 8px; align-items: center; }
+    .log-type { font-size: 11px; padding: 2px 6px; border-radius: var(--radius-md); }
+    .log-type.auto { background: var(--bg-info); color: var(--text-info); }
+    .log-type.manual { background: var(--bg-warning); color: var(--text-warning); }
+    .log-time { font-size: 12px; color: var(--text-secondary); }
+  </style>
+</head>
+<body>
+  <div class="dashboard">
+
+    <div class="topbar">
+      <h1>스마트 빌딩 관제 대시보드</h1>
+      <div style="display:flex;align-items:center;gap:16px;">
+        <span id="clock" style="font-size:13px;color:var(--text-secondary)"></span>
+        <button onclick="logout()" style="font-size:12px;padding:5px 12px;border-radius:var(--radius-md);border:0.5px solid var(--border);background:var(--bg-secondary);color:var(--text-secondary);cursor:pointer;font-family:inherit;">로그아웃</button>
+      </div>
+    </div>
+
+    <div class="summary-grid">
+      <div class="summary-card"><div class="label">전체 센서</div><div class="value" id="summary-sensor">-</div></div>
+      <div class="summary-card"><div class="label">이상 발생</div><div class="value danger" id="summary-alert">-</div></div>
+      <div class="summary-card"><div class="label">현재 소비전력</div><div class="value" id="summary-watt">-</div></div>
+      <div class="summary-card"><div class="label">에너지 절감률</div><div class="value success" id="summary-efficiency">-</div></div>
+    </div>
+
+    <div class="main-grid">
+      <div class="card">
+        <div class="card-title">센서 현황 및 제어</div>
+        <div class="room-list">
+
+          <div class="room-item" data-room="101">
+            <div class="room-top">
+              <div>
+                <div class="room-name">room-101 · 1층 회의실</div>
+                <div class="room-sub">온도 24.5° / 습도 60% / 움직임 있음</div>
+              </div>
+              <span class="badge normal">정상</span>
+            </div>
+            <div class="room-bottom">
+              <button class="ctrl-btn on" data-device="조명" onclick="manualToggle(this)">조명 ON</button>
+              <button class="ctrl-btn on" data-device="에어컨" onclick="manualToggle(this)">에어컨 ON</button>
+            </div>
+          </div>
+
+          <div class="room-item" data-room="102">
+            <div class="room-top">
+              <div>
+                <div class="room-name">room-102 · 1층 사무실</div>
+                <div class="room-sub">온도 41.0° / 습도 95% / 움직임 있음</div>
+              </div>
+              <span class="badge anomaly">이상</span>
+            </div>
+            <div class="room-bottom">
+              <button class="ctrl-btn on" data-device="조명" onclick="manualToggle(this)">조명 ON</button>
+              <button class="ctrl-btn" data-device="에어컨" onclick="manualToggle(this)">에어컨 OFF</button>
+            </div>
+          </div>
+
+          <div class="room-item" data-room="103">
+            <div class="room-top">
+              <div>
+                <div class="room-name">room-103 · 2층 회의실</div>
+                <div class="room-sub">온도 22.0° / 습도 55% / 움직임 없음</div>
+              </div>
+              <span class="badge normal">정상</span>
+            </div>
+            <div class="room-bottom">
+              <button class="ctrl-btn" data-device="조명" onclick="manualToggle(this)">조명 OFF</button>
+              <button class="ctrl-btn" data-device="에어컨" onclick="manualToggle(this)">에어컨 OFF</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title">이상 이벤트</div>
+        <div class="alert-list">
+          <div class="alert-item">
+            <div class="alert-dot danger"></div>
+            <div>
+              <div class="alert-title">room-102 온도 이상 (41.0°)</div>
+              <div class="alert-sub">09:28 · 긴급 알림 자동 전송</div>
+            </div>
+          </div>
+          <div class="alert-item">
+            <div class="alert-dot danger"></div>
+            <div>
+              <div class="alert-title">room-102 습도 이상 (95%)</div>
+              <div class="alert-sub">09:28 · 환기 명령 자동 전송</div>
+            </div>
+          </div>
+          <div class="alert-item">
+            <div class="alert-dot warning"></div>
+            <div>
+              <div class="alert-title">room-101 새벽 움직임 감지</div>
+              <div class="alert-sub">03:20 · 경보 알림 전송</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="energy-grid">
+      <div class="energy-card">
+        <div class="energy-label">오늘 누적 전력량</div>
+        <div class="energy-value" id="energy-daily">- kWh</div>
+        <div class="energy-sub" id="energy-daily-sub">어제 대비 -</div>
+        <div class="progress-bar"><div class="progress-fill" style="width:60%;background:#1D9E75"></div></div>
+      </div>
+      <div class="energy-card">
+        <div class="energy-label">자동 제어 비율</div>
+        <div class="energy-value" id="energy-efficiency">-%</div>
+        <div class="energy-sub" id="energy-efficiency-sub">수동 개입 -% </div>
+        <div class="progress-bar"><div class="progress-fill" id="energy-efficiency-bar" style="width:0%;background:#1D9E75"></div></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">제어 이력</div>
+      <div class="log-list" id="log">
+        <div class="log-item">
+          <span class="log-text">room-101 조명 ON</span>
+          <div class="log-right"><span class="log-type auto">자동</span><span class="log-time">09:00:00</span></div>
+        </div>
+        <div class="log-item">
+          <span class="log-text">room-102 에어컨 OFF</span>
+          <div class="log-right"><span class="log-type manual">수동</span><span class="log-time">09:15:00</span></div>
+        </div>
+        <div class="log-item">
+          <span class="log-text">room-103 조명 OFF</span>
+          <div class="log-right"><span class="log-type auto">자동</span><span class="log-time">09:20:00</span></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // 인증 체크 - 토큰 없으면 로그인 페이지로
+    const TOKEN = localStorage.getItem('iot_token');
+    if (!TOKEN) location.href = 'login.html';
+
+    function logout() {
+      localStorage.removeItem('iot_token');
+      location.href = 'login.html';
+    }
+
+    function authFetch(url, options = {}) {
+      return fetch(url, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + TOKEN,
+          ...(options.headers || {})
+        }
+      });
+    }
+
+    function updateClock() {
+      document.getElementById('clock').textContent = new Date().toLocaleString('ko-KR');
+    }
+    updateClock();
+    setInterval(updateClock, 1000);
+
+    function addLog(room, device, action, type) {
+      const time = new Date().toTimeString().slice(0, 8);
+      const log = document.getElementById('log');
+      const entry = document.createElement('div');
+      entry.className = 'log-item';
+      entry.innerHTML = `
+        <span class="log-text">room-${room} ${device} ${action}</span>
+        <div class="log-right">
+          <span class="log-type ${type}">${type === 'manual' ? '수동' : '자동'}</span>
+          <span class="log-time">${time}</span>
+        </div>`;
+      log.appendChild(entry);
+      log.scrollTop = log.scrollHeight;
+    }
+
+    function updateBtn(btn, action) {
+      const device = btn.dataset.device;
+      btn.textContent = device + ' ' + action;
+      btn.className = 'ctrl-btn' + (action === 'ON' ? ' on' : '');
+    }
+
+    // 수동 제어 - 버튼 클릭 시
+    async function manualToggle(btn) {
+      const isOn      = btn.textContent.includes('ON');
+      const newAction = isOn ? 'OFF' : 'ON';
+      const dataRoom  = btn.closest('.room-item').dataset.room;
+      const device    = btn.dataset.device;
+
+      updateBtn(btn, newAction);
+      addLog(dataRoom, device, newAction, 'manual');
+
+      try {
+        await authFetch('http://localhost:8080/v1/control', {
+          method: 'POST',
+          body: JSON.stringify({
+            room_id:   DATA_ROOM_TO_DB[dataRoom],
+            device_id: DEVICE_ID_MAP[device],
+            action:    newAction
+          })
+        });
+      } catch (e) {}
+    }
+
+    function autoControl(room, device, action) {
+      const roomEl = document.querySelector(`.room-item[data-room="${room}"]`);
+      if (!roomEl) return;
+      const btn = Array.from(roomEl.querySelectorAll('.ctrl-btn'))
+        .find(b => b.dataset.device === device);
+      if (!btn) return;
+      updateBtn(btn, action);
+      addLog(room, device, action, 'auto');
+    }
+
+    // DB roomId(1,2,3) → HTML data-room(101,102,103) 매핑
+    const ROOM_ID_MAP     = { 1: '101', 2: '102', 3: '103' };
+    const ROOM_NAME_MAP   = { 1: '1층 회의실', 2: '1층 사무실', 3: '2층 회의실' };
+    const DATA_ROOM_TO_DB = { '101': '1', '102': '2', '103': '3' };
+    const DEVICE_ID_MAP   = { '조명': '1', '에어컨': '2' };
+
+    function updateRoomSensor(data) {
+      const dataRoom = ROOM_ID_MAP[data.roomId];
+      if (!dataRoom) return;
+      const roomEl = document.querySelector(`.room-item[data-room="${dataRoom}"]`);
+      if (!roomEl) return;
+
+      const temp    = data.temperature != null ? `온도 ${parseFloat(data.temperature).toFixed(1)}°` : null;
+      const hum     = data.humidity    != null ? `습도 ${parseFloat(data.humidity).toFixed(0)}%`    : null;
+      const motion  = data.motion      != null ? (data.motion === 1 ? '움직임 있음' : '움직임 없음') : null;
+      const parts   = [temp, hum, motion].filter(Boolean);
+      roomEl.querySelector('.room-sub').textContent = parts.join(' / ');
+
+      const badge = roomEl.querySelector('.badge');
+      if (data.motion === 0 && data.temperature == null && data.humidity == null) {
+        badge.className = 'badge empty';
+        badge.textContent = '공실';
+      } else if (data.status === 'ANOMALY') {
+        badge.className = 'badge anomaly';
+        badge.textContent = '이상';
+      } else {
+        badge.className = 'badge normal';
+        badge.textContent = '정상';
+      }
+
+      updateAnomalyCount();
+    }
+
+    async function fetchEnergy() {
+      try {
+        const [dailyRes, efficiencyRes] = await Promise.all([
+          authFetch('http://localhost:8080/v1/energy/daily'),
+          authFetch('http://localhost:8080/v1/energy/efficiency')
+        ]);
+        const daily      = await dailyRes.json();
+        const efficiency = await efficiencyRes.json();
+
+        document.getElementById('energy-daily').textContent = parseFloat(daily.totalWh).toFixed(4) + ' kWh';
+
+        const subEl = document.getElementById('energy-daily-sub');
+        if (daily.yesterdayDiffWh != null) {
+          const diff = parseFloat(daily.yesterdayDiffWh);
+          const sign = diff >= 0 ? '+' : '';
+          subEl.textContent = '어제 대비 ' + sign + diff.toFixed(4) + ' kWh';
+        } else {
+          subEl.textContent = '어제 데이터 없음';
+        }
+
+        const eff = efficiency.efficiency;
+        document.getElementById('energy-efficiency').textContent     = eff + '%';
+        document.getElementById('energy-efficiency-sub').textContent = '수동 개입 ' + (100 - eff) + '%';
+        document.getElementById('energy-efficiency-bar').style.width = eff + '%';
+      } catch (e) {}
+    }
+
+    async function fetchSummary() {
+      try {
+        const res  = await authFetch('http://localhost:8080/v1/dashboard/summary');
+        const data = await res.json();
+        document.getElementById('summary-sensor').textContent     = data.totalSenorCount + '개';
+        document.getElementById('summary-alert').textContent      = data.totalAlertCount + '건';
+        document.getElementById('summary-watt').textContent       = data.currentTotalWatt.toLocaleString() + 'W';
+        document.getElementById('summary-efficiency').textContent = data.efficiency + '%';
+      } catch (e) {}
+    }
+
+    function updateAnomalyCount() {
+      fetchSummary();
+    }
+
+    function addAlert(data) {
+      const dataRoom = ROOM_ID_MAP[data.roomId];
+      const time = new Date().toTimeString().slice(0, 5);
+      const alertList = document.querySelector('.alert-list');
+
+      const roomName = ROOM_NAME_MAP[data.roomId] || `room-${dataRoom}`;
+      const reasons = [];
+      if (data.sensorType === 'DHT22') {
+        if (data.temperature != null && parseFloat(data.temperature) > 30) reasons.push(`온도가 임계값(30.0°C)을 초과했습니다. 현재: ${parseFloat(data.temperature).toFixed(1)}°C`);
+        if (data.humidity    != null && parseFloat(data.humidity)    > 80) reasons.push(`습도가 임계값(80.0%)을 초과했습니다. 현재: ${parseFloat(data.humidity).toFixed(0)}%`);
+      }
+      if (data.sensorType === 'PIR') {
+        if (data.motion != null && data.motion === 1) reasons.push('야간 모션이 감지되었습니다.');
+      }
+      const title = `${roomName} · ${reasons.length > 0 ? reasons.join(' / ') : '이상 감지'}`;
+
+      const item = document.createElement('div');
+      item.className = 'alert-item';
+      item.innerHTML = `
+        <div class="alert-dot danger"></div>
+        <div>
+          <div class="alert-title">${title}</div>
+          <div class="alert-sub">${time} · 실시간 알림</div>
+        </div>`;
+      alertList.appendChild(item);
+      alertList.scrollTop = alertList.scrollHeight;
+    }
+
+    async function fetchControlLogs() {
+      try {
+        const res  = await authFetch('http://localhost:8080/v1/control/logs');
+        const list = await res.json();
+        const log  = document.getElementById('log');
+        log.innerHTML = '';
+        list.forEach(data => {
+          const type  = data.type === 'MANUAL' ? 'manual' : 'auto';
+          const label = type === 'manual' ? '수동' : '자동';
+          const entry = document.createElement('div');
+          entry.className = 'log-item';
+          entry.innerHTML = `
+            <span class="log-text">${data.roomName} ${data.deviceName} ${data.action}</span>
+            <div class="log-right">
+              <span class="log-type ${type}">${label}</span>
+              <span class="log-time">${data.createdAt}</span>
+            </div>`;
+          log.appendChild(entry);
+        });
+        log.scrollTop = log.scrollHeight;
+      } catch (e) {}
+    }
+
+    async function fetchAlerts() {
+      try {
+        const res       = await authFetch('http://localhost:8080/v1/alerts');
+        const list      = await res.json();
+        const alertList = document.querySelector('.alert-list');
+        alertList.innerHTML = '';
+        list.forEach(data => {
+          const time     = new Date(data.createdAt).toTimeString().slice(0, 5);
+          const dotClass = data.type === 'NIGHT_MOTION' ? 'warning' : 'danger';
+          const item     = document.createElement('div');
+          item.className = 'alert-item';
+          item.innerHTML = `
+            <div class="alert-dot ${dotClass}"></div>
+            <div>
+              <div class="alert-title">${data.roomName} · ${data.message}</div>
+              <div class="alert-sub">${time}</div>
+            </div>`;
+          alertList.appendChild(item);
+        });
+        alertList.scrollTop = alertList.scrollHeight;
+      } catch (e) {}
+    }
+
+    async function fetchRoomDeviceStatuses() {
+      try {
+        await Promise.all([1, 2, 3].map(async roomId => {
+          const res  = await authFetch(`http://localhost:8080/v1/rooms/${roomId}/devices`);
+          const list = await res.json();
+          const dataRoom = ROOM_ID_MAP[roomId];
+          const roomEl  = document.querySelector(`.room-item[data-room="${dataRoom}"]`);
+          if (!roomEl) return;
+          list.forEach(d => {
+            const btn = Array.from(roomEl.querySelectorAll('.ctrl-btn'))
+              .find(b => b.dataset.device === d.deviceName);
+            if (btn) updateBtn(btn, d.status);
+          });
+        }));
+      } catch (e) {}
+    }
+
+    fetchSummary();
+    fetchEnergy();
+    fetchControlLogs();
+    fetchAlerts();
+    fetchRoomDeviceStatuses();
+    setInterval(fetchEnergy, 2000);
+    setInterval(fetchSummary, 2000);
+
+    function applyAutoControl(data) {
+      const dataRoom = ROOM_ID_MAP[data.roomId];
+      if (!dataRoom) return;
+      const roomEl = document.querySelector(`.room-item[data-room="${dataRoom}"]`);
+      if (!roomEl) return;
+      const btn = Array.from(roomEl.querySelectorAll('.ctrl-btn'))
+        .find(b => b.dataset.device === data.deviceName);
+      if (!btn) return;
+      updateBtn(btn, data.action);
+      addLog(dataRoom, data.deviceName, data.action, 'auto');
+    }
+
+    // WebSocket 연결
+    (function connectWS() {
+      const socket = new SockJS('http://localhost:8080/ws');
+      const stomp  = Stomp.over(socket);
+      stomp.debug  = null;
+
+      stomp.connect({}, () => {
+        [1, 2, 3].forEach(roomId => {
+          stomp.subscribe(`/topic/rooms/${roomId}`,          msg => updateRoomSensor(JSON.parse(msg.body)));
+          stomp.subscribe(`/topic/rooms/${roomId}/alerts`,   msg => addAlert(JSON.parse(msg.body)));
+          stomp.subscribe(`/topic/rooms/${roomId}/control`,  msg => applyAutoControl(JSON.parse(msg.body)));
+        });
+      }, () => {
+        setTimeout(connectWS, 3000);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>스마트 빌딩 관제 — 로그인</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg-primary: #ffffff;
+      --bg-secondary: #f5f5f4;
+      --bg-tertiary: #f0efed;
+      --bg-info: #e6f1fb;
+      --bg-danger: #fcebeb;
+      --text-primary: #1a1a18;
+      --text-secondary: #5f5e5a;
+      --text-info: #185fa5;
+      --text-danger: #a32d2d;
+      --border: rgba(0,0,0,0.12);
+      --border-info: rgba(24,95,165,0.3);
+      --radius-md: 8px;
+      --radius-lg: 12px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1c1c1a;
+        --bg-secondary: #252523;
+        --bg-tertiary: #2c2c2a;
+        --bg-info: #0c2a4a;
+        --bg-danger: #2a0e0e;
+        --text-primary: #e8e6df;
+        --text-secondary: #9c9a92;
+        --text-info: #85b7eb;
+        --text-danger: #f09595;
+        --border: rgba(255,255,255,0.1);
+        --border-info: rgba(133,183,235,0.3);
+      }
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg-tertiary);
+      color: var(--text-primary);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .login-wrap {
+      width: 100%;
+      max-width: 380px;
+    }
+    .login-header {
+      margin-bottom: 2rem;
+      text-align: center;
+    }
+    .login-header h1 {
+      font-size: 18px;
+      font-weight: 500;
+      margin-bottom: 6px;
+    }
+    .login-header p {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+    .login-card {
+      background: var(--bg-primary);
+      border: 0.5px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 1.75rem 1.5rem;
+    }
+    .field {
+      margin-bottom: 1rem;
+    }
+    .field label {
+      display: block;
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-bottom: 6px;
+      font-weight: 500;
+    }
+    .field input {
+      width: 100%;
+      padding: 10px 12px;
+      font-size: 14px;
+      border: 0.5px solid var(--border);
+      border-radius: var(--radius-md);
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 0.15s;
+      font-family: inherit;
+    }
+    .field input:focus {
+      border-color: var(--border-info);
+      background: var(--bg-info);
+    }
+    .error-msg {
+      font-size: 12px;
+      color: var(--text-danger);
+      background: var(--bg-danger);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      margin-bottom: 1rem;
+      display: none;
+    }
+    .login-btn {
+      width: 100%;
+      padding: 11px;
+      font-size: 14px;
+      font-weight: 500;
+      border: none;
+      border-radius: var(--radius-md);
+      background: var(--text-info);
+      color: #fff;
+      cursor: pointer;
+      transition: opacity 0.15s;
+      font-family: inherit;
+    }
+    .login-btn:hover { opacity: 0.85; }
+    .login-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  </style>
+</head>
+<body>
+  <div class="login-wrap">
+    <div class="login-header">
+      <h1>스마트 빌딩 관제 대시보드</h1>
+      <p>관리자 계정으로 로그인하세요</p>
+    </div>
+    <div class="login-card">
+      <div class="field">
+        <label for="email">이메일</label>
+        <input type="email" id="email" placeholder="admin@example.com" autocomplete="username">
+      </div>
+      <div class="field">
+        <label for="password">비밀번호</label>
+        <input type="password" id="password" placeholder="비밀번호 입력" autocomplete="current-password">
+      </div>
+      <div class="error-msg" id="error-msg"></div>
+      <button class="login-btn" id="login-btn" onclick="doLogin()">로그인</button>
+    </div>
+  </div>
+
+  <script>
+    const SERVER = 'http://localhost:8080';
+
+    // 이미 로그인된 경우 대시보드로
+    if (localStorage.getItem('iot_token')) {
+      location.href = 'dashboard.html';
+    }
+
+    document.getElementById('password').addEventListener('keydown', e => {
+      if (e.key === 'Enter') doLogin();
+    });
+
+    async function doLogin() {
+      const email    = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      const btn      = document.getElementById('login-btn');
+      const errEl    = document.getElementById('error-msg');
+
+      errEl.style.display = 'none';
+
+      if (!email || !password) {
+        showError('이메일과 비밀번호를 입력해주세요.');
+        return;
+      }
+
+      btn.disabled = true;
+      btn.textContent = '로그인 중...';
+
+      try {
+        const res = await fetch(`${SERVER}/v1/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          localStorage.setItem('iot_token', data.token);
+          location.href = 'dashboard.html';
+        } else {
+          const err = await res.json().catch(() => ({}));
+          showError(err.message || '이메일 또는 비밀번호가 올바르지 않습니다.');
+        }
+      } catch (e) {
+        showError('서버에 연결할 수 없습니다.');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '로그인';
+      }
+    }
+
+    function showError(msg) {
+      const el = document.getElementById('error-msg');
+      el.textContent = msg;
+      el.style.display = 'block';
+    }
+  </script>
+</body>
+</html>

--- a/src/main/java/ac/gachon/iot/IotApplication.java
+++ b/src/main/java/ac/gachon/iot/IotApplication.java
@@ -2,10 +2,10 @@ package ac.gachon.iot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import java.util.TimeZone;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class IotApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/ac/gachon/iot/IotApplication.java
+++ b/src/main/java/ac/gachon/iot/IotApplication.java
@@ -2,10 +2,12 @@ package ac.gachon.iot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class IotApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/ac/gachon/iot/config/CorsConfig.java
+++ b/src/main/java/ac/gachon/iot/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package ac.gachon.iot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/java/ac/gachon/iot/config/PasswordEncoderConfig.java
+++ b/src/main/java/ac/gachon/iot/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package ac.gachon.iot.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(10);
+    }
+}

--- a/src/main/java/ac/gachon/iot/config/WebSocketConfig.java
+++ b/src/main/java/ac/gachon/iot/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package ac.gachon.iot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+
+}

--- a/src/main/java/ac/gachon/iot/controller/AlertController.java
+++ b/src/main/java/ac/gachon/iot/controller/AlertController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AlertController {
 
-    public final AlertLogService alertLogService;
+    private final AlertLogService alertLogService;
 
     @GetMapping("/v1/alerts")
     public List<AlertLogResponse> getAlerts() {

--- a/src/main/java/ac/gachon/iot/controller/RoomController.java
+++ b/src/main/java/ac/gachon/iot/controller/RoomController.java
@@ -1,6 +1,8 @@
 package ac.gachon.iot.controller;
 
+import ac.gachon.iot.domain.repository.RoomDeviceRepository;
 import ac.gachon.iot.dto.AllRoomsResponse;
+import ac.gachon.iot.dto.RoomDeviceStatusResponse;
 import ac.gachon.iot.dto.RoomSensorLatestResponse;
 import ac.gachon.iot.service.RoomService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +20,7 @@ import java.util.List;
 public class RoomController {
 
     private final RoomService roomService;
+    private final RoomDeviceRepository roomDeviceRepository;
 
     @GetMapping("")
     public List<AllRoomsResponse> getAllRooms() {
@@ -28,7 +31,12 @@ public class RoomController {
     public RoomSensorLatestResponse getLatestSensorsByRoom(@Parameter(description = "방 ID", required = true)
                                                            @PathVariable Long roomId) {
         return roomService.findLatestSensorsByRoom(roomId);
+    }
 
-
+    @GetMapping("{roomId}/devices")
+    public List<RoomDeviceStatusResponse> getRoomDeviceStatuses(@PathVariable Long roomId) {
+        return roomDeviceRepository.findByRoomId(roomId).stream()
+                .map(RoomDeviceStatusResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/ac/gachon/iot/controller/TestIngestController.java
+++ b/src/main/java/ac/gachon/iot/controller/TestIngestController.java
@@ -1,0 +1,28 @@
+package ac.gachon.iot.controller;
+
+import ac.gachon.iot.dto.MqttSensorPayload;
+import ac.gachon.iot.service.SensorDataIngestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+
+@Profile("!prod")
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestIngestController {
+
+    private final SensorDataIngestionService sensorDataIngestionService;
+
+    @PostMapping("/ingest/{identifier}")
+    public void ingest(
+            @PathVariable String identifier,
+            @RequestParam(defaultValue = "25.0") BigDecimal temperature,
+            @RequestParam(defaultValue = "50.0") BigDecimal humidity,
+            @RequestParam(defaultValue = "0") Short motion
+    ) {
+        sensorDataIngestionService.ingest(identifier, new MqttSensorPayload(temperature, humidity, motion));
+    }
+}

--- a/src/main/java/ac/gachon/iot/domain/entity/RoomDevice.java
+++ b/src/main/java/ac/gachon/iot/domain/entity/RoomDevice.java
@@ -36,4 +36,9 @@ public class RoomDevice {
 
     @Column(nullable = false)
     private OffsetDateTime updatedAt = OffsetDateTime.now();
+
+    public void updateStatus(DeviceStatus status) {
+        this.status = status;
+        this.updatedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/ac/gachon/iot/domain/repository/AlertLogRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/AlertLogRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface AlertLogRepository extends JpaRepository<AlertLog, Long> {
 
     @Query("""
-            select new ac.gachon.iot.dto.AlertLogResponse(a.id,a.type,a.message,a.createdAt,s.name)
+            select new ac.gachon.iot.dto.AlertLogResponse(a.id,a.type,a.message,a.createdAt,r.name)
                         from AlertLog a join a.sensor s join s.room r
             """)
     List<AlertLogResponse> findALlAlerts();

--- a/src/main/java/ac/gachon/iot/domain/repository/ControlLogRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/ControlLogRepository.java
@@ -3,6 +3,8 @@ package ac.gachon.iot.domain.repository;
 import ac.gachon.iot.domain.entity.ControlLog;
 import ac.gachon.iot.domain.entity.Device;
 import ac.gachon.iot.domain.entity.Room;
+import ac.gachon.iot.domain.enums.ControlMode;
+import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.dto.ControlLogResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +19,11 @@ public interface ControlLogRepository extends JpaRepository<ControlLog, Long> {
     @Query("SELECT c FROM ControlLog c JOIN FETCH c.room JOIN FETCH c.device WHERE c.createdAt BETWEEN :start AND :end")
     List<ControlLog> findByCreatedAtBetween(OffsetDateTime start, OffsetDateTime end);
 
-    Optional<ControlLog> findTopByRoomAndDeviceOrderByCreatedAtDesc(Room room, Device device);
+    Optional<ControlLog> findTopByRoomAndDeviceAndActionAndCreatedAtBeforeOrderByCreatedAtDesc(Room room, Device device, DeviceStatus action, OffsetDateTime before);
+
+    long countByTypeAndCreatedAtBetween(ControlMode type, OffsetDateTime start, OffsetDateTime end);
+
+    long countByCreatedAtBetween(OffsetDateTime start, OffsetDateTime end);
 
     @Query("""
             SELECT a

--- a/src/main/java/ac/gachon/iot/domain/repository/DeviceRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/DeviceRepository.java
@@ -5,8 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+    Optional<Device> findByName(String name);
     @Query("""
                     select sum(d.powerWatt)
                     from Device d join RoomDevice r on d.id=r.device.id                             

--- a/src/main/java/ac/gachon/iot/domain/repository/RoomDeviceRepository.java
+++ b/src/main/java/ac/gachon/iot/domain/repository/RoomDeviceRepository.java
@@ -1,14 +1,20 @@
 package ac.gachon.iot.domain.repository;
 
+import ac.gachon.iot.domain.entity.Device;
+import ac.gachon.iot.domain.entity.Room;
 import ac.gachon.iot.domain.entity.RoomDevice;
+import ac.gachon.iot.domain.entity.RoomDeviceId;
 import ac.gachon.iot.domain.enums.DeviceStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface RoomDeviceRepository extends JpaRepository<RoomDevice, Long> {
+public interface RoomDeviceRepository extends JpaRepository<RoomDevice, RoomDeviceId> {
 
     @Query("""
             select sum(d.powerWatt)
@@ -16,4 +22,9 @@ public interface RoomDeviceRepository extends JpaRepository<RoomDevice, Long> {
             where r.status=:status
             """)
     Long findCurrentTotalWatt(@Param("status") DeviceStatus status);
+
+    Optional<RoomDevice> findByRoomAndDevice(Room room, Device device);
+
+    @Query("SELECT rd FROM RoomDevice rd JOIN FETCH rd.device WHERE rd.room.id = :roomId")
+    List<RoomDevice> findByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/ac/gachon/iot/dto/ControlMessage.java
+++ b/src/main/java/ac/gachon/iot/dto/ControlMessage.java
@@ -1,0 +1,13 @@
+package ac.gachon.iot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ControlMessage {
+    private Long roomId;
+    private String deviceName;
+    private String action;
+    private String type;
+}

--- a/src/main/java/ac/gachon/iot/dto/EnergyDailyResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/EnergyDailyResponse.java
@@ -14,4 +14,6 @@ public class EnergyDailyResponse {
 
     private Double totalWh;
 
+    private Double yesterdayDiffWh;
+
 }

--- a/src/main/java/ac/gachon/iot/dto/RoomDeviceStatusResponse.java
+++ b/src/main/java/ac/gachon/iot/dto/RoomDeviceStatusResponse.java
@@ -1,0 +1,19 @@
+package ac.gachon.iot.dto;
+
+import ac.gachon.iot.domain.entity.RoomDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RoomDeviceStatusResponse {
+    private String deviceName;
+    private String status;
+
+    public static RoomDeviceStatusResponse from(RoomDevice rd) {
+        return RoomDeviceStatusResponse.builder()
+                .deviceName(rd.getDevice().getName())
+                .status(rd.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/ac/gachon/iot/dto/SensorDataMessage.java
+++ b/src/main/java/ac/gachon/iot/dto/SensorDataMessage.java
@@ -1,0 +1,21 @@
+package ac.gachon.iot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class SensorDataMessage {
+    private Long sensorId;
+    private Long roomId;
+    private String sensorIdentifier;
+    private String sensorType;      // SensorType.name
+    private BigDecimal temperature;
+    private BigDecimal humidity;
+    private Short motion;
+    private String status;          // "NORMAL" | "ANOMALY"
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/ac/gachon/iot/service/AlertEmailService.java
+++ b/src/main/java/ac/gachon/iot/service/AlertEmailService.java
@@ -1,0 +1,48 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.enums.AlertType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlertEmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String from;
+
+    @Value("${alert.email.recipient}")
+    private String recipient;
+
+    @Async
+    public void sendAlert(String sensorIdentifier, AlertType alertType, String alertMessage) {
+        if (recipient == null || recipient.isBlank()) {
+            log.warn("Alert email skipped — ALERT_EMAIL_RECIPIENT is not configured.");
+            return;
+        }
+        try {
+            SimpleMailMessage mail = new SimpleMailMessage();
+            mail.setFrom(from);
+            mail.setTo(recipient);
+            mail.setSubject("[IoT Alert] " + alertType.name());
+            mail.setText(
+                    "센서: " + sensorIdentifier + "\n" +
+                    "이상 유형: " + alertType.name() + "\n" +
+                    "내용: " + alertMessage
+            );
+            mailSender.send(mail);
+            log.info("Alert email sent. alertType={}, recipient={}", alertType, recipient);
+        } catch (MailException e) {
+            log.error("Failed to send alert email. alertType={}", alertType, e);
+        }
+    }
+}

--- a/src/main/java/ac/gachon/iot/service/AlertLogService.java
+++ b/src/main/java/ac/gachon/iot/service/AlertLogService.java
@@ -16,7 +16,6 @@ public class AlertLogService {
     private final AlertLogRepository alertLogRepository;
 
     public List<AlertLogResponse> findAllAlerts() {
-        List<AlertLogResponse> list = alertLogRepository.findALlAlerts();
         return alertLogRepository.findALlAlerts();
     }
 }

--- a/src/main/java/ac/gachon/iot/service/AuthService.java
+++ b/src/main/java/ac/gachon/iot/service/AuthService.java
@@ -7,6 +7,7 @@ import ac.gachon.iot.dto.AuthLoginRequest;
 import ac.gachon.iot.dto.AuthLoginResponse;
 import ac.gachon.iot.exception.InvalidCredentialsException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,13 +17,14 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AuthLoginResponse login(AuthLoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
-        if (!user.getPassword().equals(request.getPassword())) {
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 

--- a/src/main/java/ac/gachon/iot/service/AuthService.java
+++ b/src/main/java/ac/gachon/iot/service/AuthService.java
@@ -6,8 +6,6 @@ import ac.gachon.iot.domain.repository.UserRepository;
 import ac.gachon.iot.dto.AuthLoginRequest;
 import ac.gachon.iot.dto.AuthLoginResponse;
 import ac.gachon.iot.exception.InvalidCredentialsException;
-import io.jsonwebtoken.JwtBuilder;
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,12 +19,15 @@ public class AuthService {
 
     @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
-        User user = userRepository.findByEmail(request.getEmail()).orElseThrow(() -> new InvalidCredentialsException("Invalid"));
+        if (!user.getPassword().equals(request.getPassword())) {
+            throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
 
         return AuthLoginResponse.builder()
                 .token(jwtProvider.generateToken(user.getId()))
                 .build();
-
     }
 }

--- a/src/main/java/ac/gachon/iot/service/ControlService.java
+++ b/src/main/java/ac/gachon/iot/service/ControlService.java
@@ -15,9 +15,9 @@ import ac.gachon.iot.dto.CreateControlLogRequest;
 import ac.gachon.iot.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -33,7 +33,7 @@ public class ControlService {
     private final RoomDeviceRepository roomDeviceRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
-    // 모든 제어 이력 가져오기
+    @Transactional(readOnly = true)
     public List<ControlLogResponse> findAllControlLogs() {
 
         List<ControlLog> allLogs = controlLogRepository.findAllControlLog();
@@ -50,7 +50,7 @@ public class ControlService {
 
     }
 
-    // 제어 이력 추가하기
+    @Transactional
     public ControlLogResponse createControlLog(CreateControlLogRequest request) {
         //  해당 room 객체 찾아오기
         Room room = roomRepository.findById(Long.parseLong(request.getRoom_id())).orElseThrow(() -> new NotFoundException("해당 Room 정보를 찾을 수 없습니다."));
@@ -73,6 +73,7 @@ public class ControlService {
 
     }
 
+    @Transactional
     public void autoControl(Room room, Device device, DeviceStatus action) {
         controlLogRepository.save(
                 ControlLog.builder()

--- a/src/main/java/ac/gachon/iot/service/ControlService.java
+++ b/src/main/java/ac/gachon/iot/service/ControlService.java
@@ -7,13 +7,16 @@ import ac.gachon.iot.domain.enums.ControlMode;
 import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.domain.repository.ControlLogRepository;
 import ac.gachon.iot.domain.repository.DeviceRepository;
+import ac.gachon.iot.domain.repository.RoomDeviceRepository;
 import ac.gachon.iot.domain.repository.RoomRepository;
 import ac.gachon.iot.dto.ControlLogResponse;
+import ac.gachon.iot.dto.ControlMessage;
 import ac.gachon.iot.dto.CreateControlLogRequest;
 import ac.gachon.iot.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.format.DateTimeFormatter;
@@ -27,6 +30,8 @@ public class ControlService {
     private final ControlLogRepository controlLogRepository;
     private final RoomRepository roomRepository;
     private final DeviceRepository deviceRepository;
+    private final RoomDeviceRepository roomDeviceRepository;
+    private final SimpMessagingTemplate messagingTemplate;
 
     // 모든 제어 이력 가져오기
     public List<ControlLogResponse> findAllControlLogs() {
@@ -55,21 +60,47 @@ public class ControlService {
 
         DeviceStatus deviceStatus = (request.getAction().equals("ON") ? DeviceStatus.ON : DeviceStatus.OFF);
 
-        ControlMode controlMode = ControlMode.MANUAL;
         ControlLog saved = controlLogRepository.save(
                 ControlLog.builder()
                         .room(room)
                         .device(device)
                         .action(deviceStatus)
-                        .type(controlMode)
+                        .type(ControlMode.MANUAL)
                         .build()
         );
-
-        // saved 를 return 할 수도 있지만 controller 까지 controlLog 라는 엔티티를 보여주는 것은 좋은 설계가 아니므로 DTO로 감싸서 주기
-        // from 메서드를 static 으로 지정했기 때문에 클래스를 통해서 바로 접근이 가능하다
-        // 이런 변환 팩토리 메서드는 항상 static 으로 정의하는게 관례
+        updateRoomDeviceStatus(room, device, deviceStatus);
         return ControlLogResponse.from(saved);
 
+    }
+
+    public void autoControl(Room room, Device device, DeviceStatus action) {
+        controlLogRepository.save(
+                ControlLog.builder()
+                        .room(room)
+                        .device(device)
+                        .action(action)
+                        .type(ControlMode.AUTO)
+                        .build()
+        );
+        updateRoomDeviceStatus(room, device, action);
+        log.info("Auto control executed. room={}, device={}, action={}", room.getName(), device.getName(), action);
+
+        messagingTemplate.convertAndSend("/topic/rooms/" + room.getId() + "/control",
+                ControlMessage.builder()
+                        .roomId(room.getId())
+                        .deviceName(device.getName())
+                        .action(action.name())
+                        .type("AUTO")
+                        .build()
+        );
+    }
+
+    private void updateRoomDeviceStatus(Room room, Device device, DeviceStatus status) {
+        roomDeviceRepository.findByRoomAndDevice(room, device)
+                .ifPresent(rd -> {
+                    rd.updateStatus(status);
+                    roomDeviceRepository.save(rd);
+                });
     }
 
 }

--- a/src/main/java/ac/gachon/iot/service/EnergyService.java
+++ b/src/main/java/ac/gachon/iot/service/EnergyService.java
@@ -4,12 +4,13 @@ import ac.gachon.iot.domain.entity.ControlLog;
 import ac.gachon.iot.domain.entity.EnergyDaily;
 import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.domain.repository.ControlLogRepository;
-import ac.gachon.iot.domain.repository.DeviceRepository;
 import ac.gachon.iot.domain.repository.EnergyDailyRepository;
 import ac.gachon.iot.dto.EnergyDailyResponse;
 import ac.gachon.iot.dto.EnergyEfficiencyResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import ac.gachon.iot.domain.enums.ControlMode;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -24,22 +25,30 @@ public class EnergyService {
 
     private final ControlLogRepository controlLogRepository;
     private final EnergyDailyRepository energyDailyRepository;
-    private final DeviceRepository deviceRepository;
 
     public EnergyDailyResponse findDailyUsage() {
         EnergyDaily energyDaily = getOrCreateToday();
         Double addedWh = calculateAdditional(energyDaily);
-        return updateAndReturn(energyDaily, addedWh);
+        Double yesterdayTotalWh = energyDailyRepository.findByDate(LocalDate.now().minusDays(1))
+                .map(EnergyDaily::getTotalWh)
+                .orElse(null);
+        return updateAndReturn(energyDaily, addedWh, yesterdayTotalWh);
     }
 
     public EnergyEfficiencyResponse findTotalMaxWhPerDay() {
-        EnergyDaily energyDaily = getOrCreateToday();
-        Double actualWh = calculateAdditional(energyDaily);
-        Double maxWh = deviceRepository.findTotalMaxWhPerDay();
+        OffsetDateTime start = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
+        OffsetDateTime end = OffsetDateTime.now();
 
-        double efficiency = (maxWh - actualWh) / maxWh * 100;
+        long total = controlLogRepository.countByCreatedAtBetween(start, end);
+        if (total == 0) {
+            return EnergyEfficiencyResponse.builder().efficiency(0L).build();
+        }
+
+        long autoCount = controlLogRepository.countByTypeAndCreatedAtBetween(ControlMode.AUTO, start, end);
+        long ratio = Math.round(autoCount * 100.0 / total);
+
         return EnergyEfficiencyResponse.builder()
-                .efficiency(Math.round(efficiency))
+                .efficiency(ratio)
                 .build();
     }
 
@@ -80,10 +89,10 @@ public class EnergyService {
                         .map(ControlLog::getCreatedAt)
                         .orElseGet(() ->
                                 controlLogRepository
-                                        .findTopByRoomAndDeviceOrderByCreatedAtDesc(
-                                                log.getRoom(), log.getDevice())
+                                        .findTopByRoomAndDeviceAndActionAndCreatedAtBeforeOrderByCreatedAtDesc(
+                                                log.getRoom(), log.getDevice(), DeviceStatus.ON, log.getCreatedAt())
                                         .map(ControlLog::getCreatedAt)
-                                        .orElse(start)  // 그것도 없으면 start로 대체
+                                        .orElse(start)
                         );
 
                 // ON ~ OFF 시간 계산 → Wh 변환
@@ -112,14 +121,19 @@ public class EnergyService {
         return addedWh;
     }
 
-    private EnergyDailyResponse updateAndReturn(EnergyDaily today, Double addedWh) {
+    private EnergyDailyResponse updateAndReturn(EnergyDaily today, Double addedWh, Double yesterdayTotalWh) {
         today.setTotalWh(today.getTotalWh() + addedWh);
         today.setLastCalculatedAt(OffsetDateTime.now());
         energyDailyRepository.save(today);
 
+        Double diffWh = yesterdayTotalWh != null
+                ? (today.getTotalWh() - yesterdayTotalWh) / 1000
+                : null;
+
         return EnergyDailyResponse.builder()
                 .totalWh(today.getTotalWh() / 1000)
                 .date(today.getLastCalculatedAt())
+                .yesterdayDiffWh(diffWh)
                 .build();
     }
 

--- a/src/main/java/ac/gachon/iot/service/EnergyService.java
+++ b/src/main/java/ac/gachon/iot/service/EnergyService.java
@@ -9,6 +9,7 @@ import ac.gachon.iot.dto.EnergyDailyResponse;
 import ac.gachon.iot.dto.EnergyEfficiencyResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import ac.gachon.iot.domain.enums.ControlMode;
 
@@ -26,6 +27,7 @@ public class EnergyService {
     private final ControlLogRepository controlLogRepository;
     private final EnergyDailyRepository energyDailyRepository;
 
+    @Transactional
     public EnergyDailyResponse findDailyUsage() {
         EnergyDaily energyDaily = getOrCreateToday();
         Double addedWh = calculateAdditional(energyDaily);
@@ -35,6 +37,7 @@ public class EnergyService {
         return updateAndReturn(energyDaily, addedWh, yesterdayTotalWh);
     }
 
+    @Transactional(readOnly = true)
     public EnergyEfficiencyResponse findTotalMaxWhPerDay() {
         OffsetDateTime start = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
         OffsetDateTime end = OffsetDateTime.now();

--- a/src/main/java/ac/gachon/iot/service/LightSchedulerService.java
+++ b/src/main/java/ac/gachon/iot/service/LightSchedulerService.java
@@ -1,0 +1,68 @@
+package ac.gachon.iot.service;
+
+import ac.gachon.iot.domain.enums.DeviceStatus;
+import ac.gachon.iot.domain.repository.DeviceRepository;
+import ac.gachon.iot.domain.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LightSchedulerService {
+
+    private final RoomRepository roomRepository;
+    private final DeviceRepository deviceRepository;
+    private final ControlService controlService;
+
+    @Scheduled(cron = "0 0 7 * * MON-FRI", zone = "Asia/Seoul")
+    public void turnOnLightsOnWeekdayMorning() {
+        log.info("Scheduled: 평일 오전 7시 조명 ON");
+        controlAllRoomLights(DeviceStatus.ON);
+    }
+
+    @Scheduled(cron = "0 0 18 * * MON-FRI", zone = "Asia/Seoul")
+    public void turnOffLightsOnWeekdayEvening() {
+        log.info("Scheduled: 평일 오후 6시 조명 OFF");
+        controlAllRoomLights(DeviceStatus.OFF);
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeLightStatus() {
+        DeviceStatus action = isBusinessHour() ? DeviceStatus.ON : DeviceStatus.OFF;
+        log.info("서버 시작 시 조명 초기화: {}", action);
+        controlAllRoomLights(action);
+    }
+
+    private boolean isBusinessHour() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        DayOfWeek day = now.getDayOfWeek();
+        int hour = now.getHour();
+        boolean isWeekday = day != DayOfWeek.SATURDAY && day != DayOfWeek.SUNDAY;
+        return isWeekday && hour >= 7 && hour < 18;
+    }
+
+    private void controlAllRoomLights(DeviceStatus action) {
+        try {
+            deviceRepository.findByName("조명").ifPresent(light ->
+                    roomRepository.findAll().forEach(room -> {
+                        try {
+                            controlService.autoControl(room, light, action);
+                        } catch (Exception e) {
+                            log.error("조명 제어 실패. room={}, action={}", room.getName(), action, e);
+                        }
+                    })
+            );
+        } catch (Exception e) {
+            log.error("조명 일괄 제어 중 오류 발생. action={}", action, e);
+        }
+    }
+}

--- a/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
+++ b/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
@@ -4,20 +4,25 @@ import ac.gachon.iot.domain.entity.AlertLog;
 import ac.gachon.iot.domain.entity.Sensor;
 import ac.gachon.iot.domain.entity.SensorData;
 import ac.gachon.iot.domain.enums.AlertType;
+import ac.gachon.iot.domain.enums.DeviceStatus;
 import ac.gachon.iot.domain.enums.SensorStatus;
 import ac.gachon.iot.domain.repository.AlertLogRepository;
+import ac.gachon.iot.domain.repository.DeviceRepository;
 import ac.gachon.iot.domain.repository.SensorDataRepository;
 import ac.gachon.iot.domain.repository.SensorRepository;
 import ac.gachon.iot.dto.MqttSensorPayload;
+import ac.gachon.iot.dto.SensorDataMessage;
 import ac.gachon.iot.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Slf4j
 @Service
@@ -27,6 +32,9 @@ public class SensorDataIngestionService {
     private final SensorRepository sensorRepository;
     private final SensorDataRepository sensorDataRepository;
     private final AlertLogRepository alertLogRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ControlService controlService;
+    private final DeviceRepository deviceRepository;
 
     @Value("${sensor.threshold.temperature.max:30.0}")
     private BigDecimal temperatureMax;
@@ -39,34 +47,85 @@ public class SensorDataIngestionService {
         Sensor sensor = sensorRepository.findByIdentifier(identifier)
                 .orElseThrow(() -> new NotFoundException("Sensor not found: " + identifier));
 
-        SensorStatus status = determineStatus(payload);
+        SensorStatus status = determineStatus(payload, sensor.getSensorType().getName());
         sensorDataRepository.save(SensorData.create(sensor, payload, status));
 
         if (status == SensorStatus.ANOMALY) {
             AlertType alertType = resolveAlertType(payload);
-            String message = resolveAlertMessage(alertType, payload);
-            alertLogRepository.save(AlertLog.create(sensor, alertType, message));
-            log.warn("Anomaly detected. identifier={}, alertType={}", identifier, alertType);
+            String alertMessage = resolveAlertMessage(alertType, payload);
+            alertLogRepository.save(AlertLog.create(sensor, alertType, alertMessage));
+            log.warn("Anomaly detected. identifier={}, alertType={}, message={}", identifier, alertType, alertMessage);
         }
 
         log.info("SensorData ingested. identifier={}, status={}", identifier, status);
+
+        SensorDataMessage message = SensorDataMessage.builder()
+                .sensorId(sensor.getId())
+                .roomId(sensor.getRoom().getId())
+                .sensorIdentifier(sensor.getIdentifier())
+                .sensorType(sensor.getSensorType().getName())
+                .temperature(payload.temperature())
+                .humidity(payload.humidity())
+                .motion(payload.motion())
+                .status(status.name())
+                .createdAt(OffsetDateTime.now())
+                .build();
+        messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId(), message);
+        if (status == SensorStatus.ANOMALY) {
+            messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId() + "/alerts", message);
+        }
+
+        // 자동 제어는 센서 저장 트랜잭션과 분리 — 제어 실패가 센서 저장에 영향 주지 않음
+        tryAutoControl(sensor, payload, status);
     }
 
-    private SensorStatus determineStatus(MqttSensorPayload payload) {
-        if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
-            return SensorStatus.ANOMALY;
+    private void tryAutoControl(Sensor sensor, MqttSensorPayload payload, SensorStatus status) {
+        String sensorTypeName = sensor.getSensorType().getName();
+        try {
+            if ("PIR".equals(sensorTypeName) && payload.motion() != null) {
+                DeviceStatus lightAction = payload.motion() == 1 ? DeviceStatus.ON : DeviceStatus.OFF;
+                deviceRepository.findByName("조명").ifPresent(light ->
+                        controlService.autoControl(sensor.getRoom(), light, lightAction));
+            }
+
+            if (status == SensorStatus.ANOMALY && "DHT22".equals(sensorTypeName)) {
+                AlertType alertType = resolveAlertType(payload);
+                if (alertType == AlertType.HIGH_TEMP || alertType == AlertType.HIGH_HUMIDITY) {
+                    deviceRepository.findByName("에어컨").ifPresent(aircon ->
+                            controlService.autoControl(sensor.getRoom(), aircon, DeviceStatus.ON));
+                }
+            } else if ("DHT22".equals(sensorTypeName)) {
+                boolean tempOk = payload.temperature() == null || payload.temperature().compareTo(temperatureMax) <= 0;
+                boolean humOk  = payload.humidity()    == null || payload.humidity().compareTo(humidityMax) <= 0;
+                if (tempOk && humOk) {
+                    deviceRepository.findByName("에어컨").ifPresent(aircon ->
+                            controlService.autoControl(sensor.getRoom(), aircon, DeviceStatus.OFF));
+                }
+            }
+        } catch (Exception e) {
+            log.error("Auto control failed. identifier={}, sensorType={}", sensor.getIdentifier(), sensorTypeName, e);
         }
-        if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
-            return SensorStatus.ANOMALY;
+    }
+
+    private SensorStatus determineStatus(MqttSensorPayload payload, String sensorType) {
+        if ("DHT22".equals(sensorType)) {
+            if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
+                return SensorStatus.ANOMALY;
+            }
+            if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
+                return SensorStatus.ANOMALY;
+            }
         }
-        if (payload.motion() != null && payload.motion() == 1 && isNightTime()) {
-            return SensorStatus.ANOMALY;
+        if ("PIR".equals(sensorType)) {
+            if (payload.motion() != null && payload.motion() == 1 && isNightTime()) {
+                return SensorStatus.ANOMALY;
+            }
         }
         return SensorStatus.NORMAL;
     }
 
     private boolean isNightTime() {
-        int hour = OffsetDateTime.now().getHour();
+        int hour = OffsetDateTime.now(ZoneId.of("Asia/Seoul")).getHour();
         return hour >= 22 || hour < 6;
     }
 

--- a/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
+++ b/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
@@ -19,6 +19,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -53,12 +55,14 @@ public class SensorDataIngestionService {
         SensorStatus status = determineStatus(payload, sensor.getSensorType().getName());
         sensorDataRepository.save(SensorData.create(sensor, payload, status));
 
+        List<Runnable> postCommitActions = new ArrayList<>();
+
         if (status == SensorStatus.ANOMALY) {
             List<AlertType> alertTypes = resolveAlertTypes(payload, sensor.getSensorType().getName());
             for (AlertType alertType : alertTypes) {
                 String alertMessage = resolveAlertMessage(alertType, payload);
                 alertLogRepository.save(AlertLog.create(sensor, alertType, alertMessage));
-                alertEmailService.sendAlert(identifier, alertType, alertMessage);
+                postCommitActions.add(() -> alertEmailService.sendAlert(identifier, alertType, alertMessage));
                 log.warn("Anomaly detected. identifier={}, alertType={}, message={}", identifier, alertType, alertMessage);
             }
         }
@@ -76,10 +80,18 @@ public class SensorDataIngestionService {
                 .status(status.name())
                 .createdAt(OffsetDateTime.now())
                 .build();
-        messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId(), message);
-        if (status == SensorStatus.ANOMALY) {
-            messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId() + "/alerts", message);
-        }
+
+        // 트랜잭션 커밋 후 외부 알림 발행 — 롤백 시 알림이 발송되지 않도록 보장
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId(), message);
+                if (status == SensorStatus.ANOMALY) {
+                    messagingTemplate.convertAndSend("/topic/rooms/" + message.getRoomId() + "/alerts", message);
+                }
+                postCommitActions.forEach(Runnable::run);
+            }
+        });
 
         // 자동 제어는 센서 저장 트랜잭션과 분리 — 제어 실패가 센서 저장에 영향 주지 않음
         tryAutoControl(sensor, payload, status);

--- a/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
+++ b/src/main/java/ac/gachon/iot/service/SensorDataIngestionService.java
@@ -23,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -35,6 +37,7 @@ public class SensorDataIngestionService {
     private final SimpMessagingTemplate messagingTemplate;
     private final ControlService controlService;
     private final DeviceRepository deviceRepository;
+    private final AlertEmailService alertEmailService;
 
     @Value("${sensor.threshold.temperature.max:30.0}")
     private BigDecimal temperatureMax;
@@ -51,10 +54,13 @@ public class SensorDataIngestionService {
         sensorDataRepository.save(SensorData.create(sensor, payload, status));
 
         if (status == SensorStatus.ANOMALY) {
-            AlertType alertType = resolveAlertType(payload);
-            String alertMessage = resolveAlertMessage(alertType, payload);
-            alertLogRepository.save(AlertLog.create(sensor, alertType, alertMessage));
-            log.warn("Anomaly detected. identifier={}, alertType={}, message={}", identifier, alertType, alertMessage);
+            List<AlertType> alertTypes = resolveAlertTypes(payload, sensor.getSensorType().getName());
+            for (AlertType alertType : alertTypes) {
+                String alertMessage = resolveAlertMessage(alertType, payload);
+                alertLogRepository.save(AlertLog.create(sensor, alertType, alertMessage));
+                alertEmailService.sendAlert(identifier, alertType, alertMessage);
+                log.warn("Anomaly detected. identifier={}, alertType={}, message={}", identifier, alertType, alertMessage);
+            }
         }
 
         log.info("SensorData ingested. identifier={}, status={}", identifier, status);
@@ -89,8 +95,10 @@ public class SensorDataIngestionService {
             }
 
             if (status == SensorStatus.ANOMALY && "DHT22".equals(sensorTypeName)) {
-                AlertType alertType = resolveAlertType(payload);
-                if (alertType == AlertType.HIGH_TEMP || alertType == AlertType.HIGH_HUMIDITY) {
+                List<AlertType> alertTypes = resolveAlertTypes(payload, sensorTypeName);
+                boolean hasThermalAnomaly = alertTypes.stream()
+                        .anyMatch(t -> t == AlertType.HIGH_TEMP || t == AlertType.HIGH_HUMIDITY);
+                if (hasThermalAnomaly) {
                     deviceRepository.findByName("에어컨").ifPresent(aircon ->
                             controlService.autoControl(sensor.getRoom(), aircon, DeviceStatus.ON));
                 }
@@ -129,14 +137,20 @@ public class SensorDataIngestionService {
         return hour >= 22 || hour < 6;
     }
 
-    private AlertType resolveAlertType(MqttSensorPayload payload) {
-        if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
-            return AlertType.HIGH_TEMP;
+    private List<AlertType> resolveAlertTypes(MqttSensorPayload payload, String sensorType) {
+        List<AlertType> types = new ArrayList<>();
+        if ("DHT22".equals(sensorType)) {
+            if (payload.temperature() != null && payload.temperature().compareTo(temperatureMax) > 0) {
+                types.add(AlertType.HIGH_TEMP);
+            }
+            if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
+                types.add(AlertType.HIGH_HUMIDITY);
+            }
         }
-        if (payload.humidity() != null && payload.humidity().compareTo(humidityMax) > 0) {
-            return AlertType.HIGH_HUMIDITY;
+        if ("PIR".equals(sensorType) && payload.motion() != null && payload.motion() == 1 && isNightTime()) {
+            types.add(AlertType.NIGHT_MOTION);
         }
-        return AlertType.NIGHT_MOTION;
+        return types;
     }
 
     private String resolveAlertMessage(AlertType alertType, MqttSensorPayload payload) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ springdoc:
     path: /v3/api-docs
 
 jwt:
-  secret: ${JWT_SECRET:K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=}
+  secret: ${JWT_SECRET}
   expiration: 86400000
 
 timezone:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,19 @@ spring:
   jackson:
     time-zone: UTC
 
+  mail:
+    host: ${MAIL_HOST:smtp.gmail.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
   datasource:
     url: jdbc:postgresql://localhost:5432/biot_db
     username: postgres
@@ -63,6 +76,10 @@ sensor:
       max: 30.0
     humidity:
       max: 80.0
+
+alert:
+  email:
+    recipient: ${ALERT_EMAIL_RECIPIENT:}
     
 management:
   endpoints:

--- a/src/main/resources/db/migration/V34__update_device_power_watt.sql
+++ b/src/main/resources/db/migration/V34__update_device_power_watt.sql
@@ -1,0 +1,2 @@
+UPDATE device SET power_watt = 500  WHERE name = '조명';
+UPDATE device SET power_watt = 5000 WHERE name = '에어컨';

--- a/src/main/resources/db/migration/V35__seed_yesterday_energy_daily.sql
+++ b/src/main/resources/db/migration/V35__seed_yesterday_energy_daily.sql
@@ -1,0 +1,5 @@
+-- 어제 누적 전력량 데이터 삽입 (어제 대비 비교 테스트용)
+-- 조명 3대(500W) × 11h + 에어컨(5000W) × 3h = 16,500 + 15,000 = 31,500 Wh
+INSERT INTO energy_daily (date, total_wh, last_calculated_at)
+VALUES (CURRENT_DATE - 1, 31500.0, NOW() - INTERVAL '1 day')
+ON CONFLICT (date) DO NOTHING;

--- a/src/main/resources/db/migration/V36__seed_admin_user.sql
+++ b/src/main/resources/db/migration/V36__seed_admin_user.sql
@@ -1,0 +1,3 @@
+INSERT INTO users (email, password)
+VALUES ('admin@gachon.ac.kr', 'admin1234')
+ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migration/V37__hash_admin_password.sql
+++ b/src/main/resources/db/migration/V37__hash_admin_password.sql
@@ -1,0 +1,3 @@
+UPDATE users
+SET password = '$2a$10$H/.L5bXujTxIF0EODz4qeuq/Cj1jQIy1Y7ZRCb0PhJA4DVy83ckTa'
+WHERE email = 'admin@gachon.ac.kr';

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <springProperty scope="context" name="LOG_PATH" source="logging.file.name" defaultValue="./logs/iot-backend.log"/>
+
+  <!-- 콘솔 출력 -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- 파일 출력 (일별 롤링, 30일 보관, 최대 500MB) -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>./logs/iot-backend.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>500MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- 애플리케이션 로그: INFO 이상 -->
+  <logger name="ac.gachon.iot" level="INFO"/>
+
+  <!-- MQTT/Flyway 노이즈 억제 -->
+  <logger name="org.flywaydb" level="WARN"/>
+  <logger name="org.eclipse.paho" level="WARN"/>
+  <logger name="org.springframework.integration" level="WARN"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>

--- a/websocket-test.html
+++ b/websocket-test.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>WebSocket Test</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #1e1e1e; color: #d4d4d4; }
+        input, button, select { padding: 6px 10px; margin: 4px; border-radius: 4px; border: 1px solid #444; background: #2d2d2d; color: #d4d4d4; }
+        button { cursor: pointer; background: #0e639c; border-color: #0e639c; }
+        button:hover { background: #1177bb; }
+        button.danger { background: #c72e2e; border-color: #c72e2e; }
+        #log { margin-top: 20px; padding: 12px; background: #2d2d2d; border-radius: 6px; height: 400px; overflow-y: auto; font-size: 13px; }
+        .msg-sensor { color: #4ec9b0; }
+        .msg-alert  { color: #f14c4c; }
+        .msg-system { color: #888; }
+        .msg-connected { color: #6a9955; }
+        h2 { color: #569cd6; }
+        label { font-size: 13px; color: #9cdcfe; }
+    </style>
+</head>
+<body>
+    <h2>WebSocket (STOMP) 테스트</h2>
+
+    <div>
+        <label>서버 URL</label><br>
+        <input id="serverUrl" type="text" value="http://localhost:8080/ws" style="width:300px;">
+        <button onclick="connect()">연결</button>
+        <button class="danger" onclick="disconnect()">연결 해제</button>
+    </div>
+
+    <div style="margin-top:12px;">
+        <label>Room ID</label><br>
+        <input id="roomId" type="number" value="1" style="width:100px;">
+        <button onclick="subscribe()">구독</button>
+        <button onclick="subscribeAlerts()">알림 구독</button>
+    </div>
+
+    <div style="margin-top:12px; border-top:1px solid #444; padding-top:12px;">
+        <label>테스트 데이터 전송</label><br>
+        <input id="identifier" type="text" placeholder="sensor identifier" style="width:160px;">
+        <input id="temperature" type="number" placeholder="온도" value="25.0" step="0.1" style="width:80px;">
+        <input id="humidity"    type="number" placeholder="습도" value="50.0" step="0.1" style="width:80px;">
+        <select id="motion">
+            <option value="0">motion: 0</option>
+            <option value="1">motion: 1</option>
+        </select>
+        <button onclick="sendTestData()">전송</button>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        let stompClient = null;
+
+        function log(msg, cls = 'msg-system') {
+            const div = document.getElementById('log');
+            const time = new Date().toLocaleTimeString();
+            div.innerHTML += `<div class="${cls}">[${time}] ${msg}</div>`;
+            div.scrollTop = div.scrollHeight;
+        }
+
+        function connect() {
+            const url = document.getElementById('serverUrl').value;
+            const socket = new SockJS(url);
+            stompClient = Stomp.over(socket);
+            stompClient.debug = null;
+
+            stompClient.connect({}, () => {
+                log('연결 성공: ' + url, 'msg-connected');
+            }, (err) => {
+                log('연결 실패: ' + err, 'msg-alert');
+            });
+        }
+
+        function disconnect() {
+            if (stompClient) {
+                stompClient.disconnect(() => log('연결 해제됨'));
+                stompClient = null;
+            }
+        }
+
+        function subscribe() {
+            if (!stompClient) return log('먼저 연결하세요.');
+            const roomId = document.getElementById('roomId').value;
+            const dest = `/topic/rooms/${roomId}`;
+            stompClient.subscribe(dest, (msg) => {
+                const body = JSON.parse(msg.body);
+                log(`[센서 데이터] ${dest}<br>&nbsp;&nbsp;${JSON.stringify(body, null, 2).replace(/\n/g, '<br>&nbsp;&nbsp;')}`, 'msg-sensor');
+            });
+            log(`구독 시작: ${dest}`);
+        }
+
+        function subscribeAlerts() {
+            if (!stompClient) return log('먼저 연결하세요.');
+            const roomId = document.getElementById('roomId').value;
+            const dest = `/topic/rooms/${roomId}/alerts`;
+            stompClient.subscribe(dest, (msg) => {
+                const body = JSON.parse(msg.body);
+                log(`[알림] ${dest}<br>&nbsp;&nbsp;${JSON.stringify(body, null, 2).replace(/\n/g, '<br>&nbsp;&nbsp;')}`, 'msg-alert');
+            });
+            log(`구독 시작: ${dest}`);
+        }
+        async function sendTestData() {
+            const identifier  = document.getElementById('identifier').value;
+            const temperature = document.getElementById('temperature').value;
+            const humidity    = document.getElementById('humidity').value;
+            const motion      = document.getElementById('motion').value;
+
+            if (!identifier) return log('sensor identifier를 입력하세요.', 'msg-alert');
+
+            const serverBase = document.getElementById('serverUrl').value.replace('/ws', '');
+            const url = `${serverBase}/test/ingest/${identifier}?temperature=${temperature}&humidity=${humidity}&motion=${motion}`;
+            try {
+                const res = await fetch(url, { method: 'POST' });
+                if (res.ok) {
+                    log(`테스트 데이터 전송: identifier=${identifier}, temp=${temperature}, humidity=${humidity}, motion=${motion}`);
+                } else {
+                    log(`전송 실패: ${res.status} ${res.statusText}`, 'msg-alert');
+                }
+            } catch (e) {
+                log('전송 오류: ' + e, 'msg-alert');
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- 방(Room)별 WebSocket 토픽 구독 구조로 실시간 센서 데이터 브로드캐스트 구현
- PIR(모션) → 조명 자동 ON/OFF, DHT22(온습도 이상) → 에어컨 자동 ON/OFF 자동 제어 로직 추가
- 평일 07:00 조명 ON / 18:00 조명 OFF 스케줄링 및 서버 시작 시 조명 상태 초기화
- JWT 기반 관리자 로그인 페이지(`login.html`) 및 실시간 대시보드(`dashboard.html`) 구현
- 에너지 일별 누적 및 어제 대비 차이 계산, 자동 제어 비율(AUTO/전체) 계산 수정
- 자동 제어 트랜잭션 분리로 제어 실패가 센서 저장에 영향 주지 않도록 예외 처리 강화
- logback-spring.xml 일별 롤링 로그 설정 (30일 보관, 500MB 상한)

## Changes

### WebSocket
- `WebSocketConfig`: STOMP over SockJS 설정
- `SensorDataMessage`: WebSocket 브로드캐스트 DTO
- `SensorDataIngestionService`: `/topic/rooms/{id}`, `/topic/rooms/{id}/alerts` 토픽으로 방별 브로드캐스트
- `ControlService.autoControl()`: `/topic/rooms/{id}/control` 토픽으로 제어 결과 브로드캐스트

### Auto Control
- PIR 센서: motion=1 → 조명 ON, motion=0 → 조명 OFF
- DHT22 센서: 온도 > 30°C 또는 습도 > 80% → 에어컨 ON / 정상 범위 복귀 → 에어컨 OFF
- `tryAutoControl()` 메서드로 제어 로직 트랜잭션 분리 및 예외 처리

### Scheduling
- `LightSchedulerService`: 평일 07:00 ON / 18:00 OFF 크론 스케줄
- `@EventListener(ApplicationReadyEvent)`: 서버 시작 시 업무 시간 여부 판단 후 조명 초기화
- 방별 제어 실패 시 해당 방만 `log.error` 기록 후 계속 진행

### Auth & Dashboard
- `AuthService`: 비밀번호 검증 로직 추가 (기존엔 이메일만 확인)
- `login.html`: 대시보드와 동일한 디자인의 관리자 로그인 페이지
- `dashboard.html`: WebSocket 실시간 수신 + REST API 2초 폴링 통합 대시보드
- 모든 API 요청에 `Authorization: Bearer <token>` 헤더 포함

### Energy & Efficiency
- `EnergyDailyResponse`: `yesterdayDiffWh` 필드 추가 (어제 대비 차이)
- `EnergyService`: AUTO/MANUAL 제어 건수 기반 자동 제어 비율 계산으로 수정

### Infra & Logging
- `CorsConfig`: 전체 라우트 CORS 허용
- `logback-spring.xml`: 일별 롤링, MQTT/Flyway 라이브러리 로그 억제
- `TestIngestController`: `@Profile("!prod")` 환경에서 센서 데이터 수동 주입 API
- `V34~V36` Flyway 마이그레이션: 기기 전력량 업데이트, 어제 에너지 시드, 관리자 계정 시드

## Test plan

- [ ] `login.html` 접속 → `admin@gachon.ac.kr` / `admin1234` 로그인 → `dashboard.html` 이동 확인
- [ ] 토큰 없이 `dashboard.html` 직접 접속 시 `login.html`로 리다이렉트 확인
- [ ] `POST /test/ingest/dht-101?temperature=35` 호출 → 에어컨 자동 ON, 이상 이벤트 등록 확인
- [ ] `POST /test/ingest/pir-101?motion=1` 호출 → 조명 자동 ON, 대시보드 실시간 반영 확인
- [ ] `POST /test/ingest/pir-101?motion=0` 호출 → 조명 자동 OFF 확인
- [ ] 야간 시간대에 `motion=1` 전송 → 이상 이벤트(NIGHT_MOTION) 등록 확인
- [ ] 대시보드 수동 제어 버튼 클릭 → control_log MANUAL 저장 및 자동 제어 비율 변화 확인
- [ ] `GET /v1/energy/daily` → `yesterdayDiffWh` 값 정상 반환 확인
- [ ] `./logs/iot-backend.log` 파일 생성 및 일별 롤링 동작 확인